### PR TITLE
feat: add context to func signatures and ability to override options

### DIFF
--- a/SUPPORTED_ENDPOINTS.md
+++ b/SUPPORTED_ENDPOINTS.md
@@ -90,7 +90,7 @@
 - [x] Create Extension Secret
 - [x] Get Extension Secret
 - [ ] Revoke Extension Secrets
-- [ ] Get Live Channels with Extension Activated
+- [x] Get Live Channels with Extension Activated
 - [x] Set Extension Required Configuration
 - [x] Set Extension Configuration Segment
 - [ ] Get Extension Channel Configuration

--- a/ads.go
+++ b/ads.go
@@ -35,8 +35,8 @@ type StartCommercialResponse struct {
 // StartCommercial starts a commercial on a specified channel
 // OAuth Token required
 // Requires channel:edit:commercial scope
-func (c *Client) StartCommercial(params *StartCommercialParams) (*StartCommercialResponse, error) {
-	resp, err := c.post("/channels/commercial", &ManyAdDetails{}, params)
+func (c *Client) StartCommercial(params *StartCommercialParams, opts ...Options) (*StartCommercialResponse, error) {
+	resp, err := c.post("/channels/commercial", &ManyAdDetails{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/ads.go
+++ b/ads.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type AdLengthEnum int
 
 const (
@@ -35,8 +37,8 @@ type StartCommercialResponse struct {
 // StartCommercial starts a commercial on a specified channel
 // OAuth Token required
 // Requires channel:edit:commercial scope
-func (c *Client) StartCommercial(params *StartCommercialParams, opts ...Options) (*StartCommercialResponse, error) {
-	resp, err := c.post("/channels/commercial", &ManyAdDetails{}, params, opts...)
+func (c *Client) StartCommercial(ctx context.Context, params *StartCommercialParams, opts ...Option) (*StartCommercialResponse, error) {
+	resp, err := c.post(ctx, "/channels/commercial", &ManyAdDetails{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/ads_test.go
+++ b/ads_test.go
@@ -1,6 +1,7 @@
 package helix
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -22,7 +23,7 @@ func TestClient_StartCommercial(t *testing.T) {
 		// Failure - broadcaster not live
 		{
 			http.StatusBadRequest,
-			&Options{ClientID: "my-client-id"},
+			&Options{clientID: "my-client-id"},
 			1,
 			"89754791",
 			AdLen30,
@@ -32,7 +33,7 @@ func TestClient_StartCommercial(t *testing.T) {
 		// success
 		{
 			http.StatusOK,
-			&Options{ClientID: "my-client-id"},
+			&Options{clientID: "my-client-id"},
 			1,
 			"41245072",
 			AdLen60,
@@ -49,7 +50,7 @@ func TestClient_StartCommercial(t *testing.T) {
 			Length:        testCase.adLength,
 		}
 
-		resp, err := c.StartCommercial(params)
+		resp, err := c.StartCommercial(context.Background(), params)
 		if err != nil {
 			t.Error(err)
 		}
@@ -89,16 +90,16 @@ func TestClient_StartCommercial(t *testing.T) {
 
 	// Test with HTTP Failure
 	options := &Options{
-		ClientID: "my-client-id",
-		HTTPClient: &badMockHTTPClient{
+		clientID: "my-client-id",
+		httpDo: (&badMockHTTPClient{
 			newMockHandler(0, "", nil),
-		},
+		}).Do,
 	}
 	c := &Client{
 		opts: options,
 	}
 
-	_, err := c.StartCommercial(&StartCommercialParams{})
+	_, err := c.StartCommercial(context.Background(), &StartCommercialParams{})
 	if err == nil {
 		t.Error("expected error but got nil")
 	}

--- a/analytics.go
+++ b/analytics.go
@@ -28,8 +28,8 @@ type ExtensionAnalyticsParams struct {
 
 // GetExtensionAnalytics returns a URL to the downloadable CSV file
 // containing analytics data. Valid for 5 minutes.
-func (c *Client) GetExtensionAnalytics(params *ExtensionAnalyticsParams) (*ExtensionAnalyticsResponse, error) {
-	resp, err := c.get("/analytics/extensions", &ManyExtensionAnalytics{}, params)
+func (c *Client) GetExtensionAnalytics(params *ExtensionAnalyticsParams, opts ...Options) (*ExtensionAnalyticsResponse, error) {
+	resp, err := c.get("/analytics/extensions", &ManyExtensionAnalytics{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +69,9 @@ type GameAnalyticsParams struct {
 
 // GetGameAnalytics returns a URL to the downloadable CSV file
 // containing analytics data for the specified game. Valid for 5 minutes.
-func (c *Client) GetGameAnalytics(params *GameAnalyticsParams) (*GameAnalyticsResponse, error) {
+func (c *Client) GetGameAnalytics(params *GameAnalyticsParams, opts ...Options) (*GameAnalyticsResponse, error) {
 
-	resp, err := c.get("/analytics/games", &ManyGameAnalytics{}, params)
+	resp, err := c.get("/analytics/games", &ManyGameAnalytics{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/analytics.go
+++ b/analytics.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type ExtensionAnalytic struct {
 	ExtensionID string    `json:"extension_id"`
 	URL         string    `json:"URL"`
@@ -28,8 +30,8 @@ type ExtensionAnalyticsParams struct {
 
 // GetExtensionAnalytics returns a URL to the downloadable CSV file
 // containing analytics data. Valid for 5 minutes.
-func (c *Client) GetExtensionAnalytics(params *ExtensionAnalyticsParams, opts ...Options) (*ExtensionAnalyticsResponse, error) {
-	resp, err := c.get("/analytics/extensions", &ManyExtensionAnalytics{}, params, opts...)
+func (c *Client) GetExtensionAnalytics(ctx context.Context, params *ExtensionAnalyticsParams, opts ...Option) (*ExtensionAnalyticsResponse, error) {
+	resp, err := c.get(ctx, "/analytics/extensions", &ManyExtensionAnalytics{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +71,8 @@ type GameAnalyticsParams struct {
 
 // GetGameAnalytics returns a URL to the downloadable CSV file
 // containing analytics data for the specified game. Valid for 5 minutes.
-func (c *Client) GetGameAnalytics(params *GameAnalyticsParams, opts ...Options) (*GameAnalyticsResponse, error) {
-
-	resp, err := c.get("/analytics/games", &ManyGameAnalytics{}, params, opts...)
+func (c *Client) GetGameAnalytics(ctx context.Context, params *GameAnalyticsParams, opts ...Option) (*GameAnalyticsResponse, error) {
+	resp, err := c.get(ctx, "/analytics/games", &ManyGameAnalytics{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/bits.go
+++ b/bits.go
@@ -1,6 +1,9 @@
 package helix
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type UserBitTotal struct {
 	UserID    string `json:"user_id"`
@@ -32,8 +35,8 @@ type BitsLeaderboardParams struct {
 // information for an authorized broadcaster.
 //
 // Required Scope: bits:read
-func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams, opts ...Options) (*BitsLeaderboardResponse, error) {
-	resp, err := c.get("/bits/leaderboard", &ManyUserBitTotals{}, params, opts...)
+func (c *Client) GetBitsLeaderboard(ctx context.Context, params *BitsLeaderboardParams, opts ...Option) (*BitsLeaderboardResponse, error) {
+	resp, err := c.get(ctx, "/bits/leaderboard", &ManyUserBitTotals{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +99,8 @@ type CheermotesResponse struct {
 	Data ManyCheermotes
 }
 
-func (c *Client) GetCheermotes(params *CheermotesParams, opts ...Options) (*CheermotesResponse, error) {
-	resp, err := c.get("/bits/cheermotes", &ManyCheermotes{}, params, opts...)
+func (c *Client) GetCheermotes(ctx context.Context, params *CheermotesParams, opts ...Option) (*CheermotesResponse, error) {
+	resp, err := c.get(ctx, "/bits/cheermotes", &ManyCheermotes{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/bits.go
+++ b/bits.go
@@ -32,8 +32,8 @@ type BitsLeaderboardParams struct {
 // information for an authorized broadcaster.
 //
 // Required Scope: bits:read
-func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams) (*BitsLeaderboardResponse, error) {
-	resp, err := c.get("/bits/leaderboard", &ManyUserBitTotals{}, params)
+func (c *Client) GetBitsLeaderboard(params *BitsLeaderboardParams, opts ...Options) (*BitsLeaderboardResponse, error) {
+	resp, err := c.get("/bits/leaderboard", &ManyUserBitTotals{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +96,8 @@ type CheermotesResponse struct {
 	Data ManyCheermotes
 }
 
-func (c *Client) GetCheermotes(params *CheermotesParams) (*CheermotesResponse, error) {
-	resp, err := c.get("/bits/cheermotes", &ManyCheermotes{}, params)
+func (c *Client) GetCheermotes(params *CheermotesParams, opts ...Options) (*CheermotesResponse, error) {
+	resp, err := c.get("/bits/cheermotes", &ManyCheermotes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels.go
+++ b/channels.go
@@ -37,8 +37,8 @@ type SearchChannelsResponse struct {
 
 // SearchChannels searches for Twitch channels based on the given search
 // parameters. Unlike GetStreams, this can also return offline channels.
-func (c *Client) SearchChannels(params *SearchChannelsParams) (*SearchChannelsResponse, error) {
-	resp, err := c.get("/search/channels", &ManySearchChannels{}, params)
+func (c *Client) SearchChannels(params *SearchChannelsParams, opts ...Options) (*SearchChannelsResponse, error) {
+	resp, err := c.get("/search/channels", &ManySearchChannels{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ type ChannelInformation struct {
 	Delay               int    `json:"delay"`
 }
 
-func (c *Client) GetChannelInformation(params *GetChannelInformationParams) (*GetChannelInformationResponse, error) {
-	resp, err := c.get("/channels", &ManyChannelInformation{}, params)
+func (c *Client) GetChannelInformation(params *GetChannelInformationParams, opts ...Options) (*GetChannelInformationResponse, error) {
+	resp, err := c.get("/channels", &ManyChannelInformation{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +101,8 @@ func (c *Client) GetChannelInformation(params *GetChannelInformationParams) (*Ge
 	return channels, nil
 }
 
-func (c *Client) EditChannelInformation(params *EditChannelInformationParams) (*EditChannelInformationResponse, error) {
-	resp, err := c.patchAsJSON("/channels", &EditChannelInformationResponse{}, params)
+func (c *Client) EditChannelInformation(params *EditChannelInformationParams, opts ...Options) (*EditChannelInformationResponse, error) {
+	resp, err := c.patchAsJSON("/channels", &EditChannelInformationResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels.go
+++ b/channels.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 // SearchChannelsParams is parameters for SearchChannels
 type SearchChannelsParams struct {
 	Channel  string `query:"query"`
@@ -37,8 +39,8 @@ type SearchChannelsResponse struct {
 
 // SearchChannels searches for Twitch channels based on the given search
 // parameters. Unlike GetStreams, this can also return offline channels.
-func (c *Client) SearchChannels(params *SearchChannelsParams, opts ...Options) (*SearchChannelsResponse, error) {
-	resp, err := c.get("/search/channels", &ManySearchChannels{}, params, opts...)
+func (c *Client) SearchChannels(ctx context.Context, params *SearchChannelsParams, opts ...Option) (*SearchChannelsResponse, error) {
+	resp, err := c.get(ctx, "/search/channels", &ManySearchChannels{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +90,8 @@ type ChannelInformation struct {
 	Delay               int    `json:"delay"`
 }
 
-func (c *Client) GetChannelInformation(params *GetChannelInformationParams, opts ...Options) (*GetChannelInformationResponse, error) {
-	resp, err := c.get("/channels", &ManyChannelInformation{}, params, opts...)
+func (c *Client) GetChannelInformation(ctx context.Context, params *GetChannelInformationParams, opts ...Option) (*GetChannelInformationResponse, error) {
+	resp, err := c.get(ctx, "/channels", &ManyChannelInformation{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +103,8 @@ func (c *Client) GetChannelInformation(params *GetChannelInformationParams, opts
 	return channels, nil
 }
 
-func (c *Client) EditChannelInformation(params *EditChannelInformationParams, opts ...Options) (*EditChannelInformationResponse, error) {
-	resp, err := c.patchAsJSON("/channels", &EditChannelInformationResponse{}, params, opts...)
+func (c *Client) EditChannelInformation(ctx context.Context, params *EditChannelInformationParams, opts ...Option) (*EditChannelInformationResponse, error) {
+	resp, err := c.patchAsJSON(ctx, "/channels", &EditChannelInformationResponse{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_editors.go
+++ b/channels_editors.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type ChannelEditorsParams struct {
 	BroadcasterID string `query:"broadcaster_id"`
 }
@@ -22,8 +24,8 @@ type ChannelEditorsResponse struct {
 
 // GetChannelEditors Get a list of users who have editor permissions for a specific channel
 // Required scope: channel:read:editors
-func (c *Client) GetChannelEditors(params *ChannelEditorsParams, opts ...Options) (*ChannelEditorsResponse, error) {
-	resp, err := c.get("/channels/editors", &ManyChannelEditors{}, params, opts...)
+func (c *Client) GetChannelEditors(ctx context.Context, params *ChannelEditorsParams, opts ...Option) (*ChannelEditorsResponse, error) {
+	resp, err := c.get(ctx, "/channels/editors", &ManyChannelEditors{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_editors.go
+++ b/channels_editors.go
@@ -22,8 +22,8 @@ type ChannelEditorsResponse struct {
 
 // GetChannelEditors Get a list of users who have editor permissions for a specific channel
 // Required scope: channel:read:editors
-func (c *Client) GetChannelEditors(params *ChannelEditorsParams) (*ChannelEditorsResponse, error) {
-	resp, err := c.get("/channels/editors", &ManyChannelEditors{}, params)
+func (c *Client) GetChannelEditors(params *ChannelEditorsParams, opts ...Options) (*ChannelEditorsResponse, error) {
+	resp, err := c.get("/channels/editors", &ManyChannelEditors{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_points.go
+++ b/channels_points.go
@@ -87,8 +87,8 @@ type DeleteCustomRewardsResponse struct {
 
 // CreateCustomReward : Creates a Custom Reward on a channel.
 // Required scope: channel:manage:redemptions
-func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params)
+func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams) (*Channe
 
 // DeleteCustomRewards : Deletes a Custom Rewards on a channel
 // Required scope: channel:manage:redemptions
-func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams) (*DeleteCustomRewardsResponse, error) {
-	resp, err := c.delete("/channel_points/custom_rewards", nil, params)
+func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams, opts ...Options) (*DeleteCustomRewardsResponse, error) {
+	resp, err := c.delete("/channel_points/custom_rewards", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +116,8 @@ func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams) (*Delete
 
 // GetCustomRewards : Get Custom Rewards on a channel
 // Required scope: channel:read:redemptions
-func (c *Client) GetCustomRewards(params *GetCustomRewardsParams) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.get("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params)
+func (c *Client) GetCustomRewards(params *GetCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.get("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/channels_points.go
+++ b/channels_points.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type ChannelCustomRewardsParams struct {
 	BroadcasterID                     string `query:"broadcaster_id"`
 	Title                             string `json:"title"`
@@ -87,8 +89,8 @@ type DeleteCustomRewardsResponse struct {
 
 // CreateCustomReward : Creates a Custom Reward on a channel.
 // Required scope: channel:manage:redemptions
-func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.postAsJSON("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
+func (c *Client) CreateCustomReward(ctx context.Context, params *ChannelCustomRewardsParams, opts ...Option) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +104,8 @@ func (c *Client) CreateCustomReward(params *ChannelCustomRewardsParams, opts ...
 
 // DeleteCustomRewards : Deletes a Custom Rewards on a channel
 // Required scope: channel:manage:redemptions
-func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams, opts ...Options) (*DeleteCustomRewardsResponse, error) {
-	resp, err := c.delete("/channel_points/custom_rewards", nil, params, opts...)
+func (c *Client) DeleteCustomRewards(ctx context.Context, params *DeleteCustomRewardsParams, opts ...Option) (*DeleteCustomRewardsResponse, error) {
+	resp, err := c.delete(ctx, "/channel_points/custom_rewards", nil, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +118,8 @@ func (c *Client) DeleteCustomRewards(params *DeleteCustomRewardsParams, opts ...
 
 // GetCustomRewards : Get Custom Rewards on a channel
 // Required scope: channel:read:redemptions
-func (c *Client) GetCustomRewards(params *GetCustomRewardsParams, opts ...Options) (*ChannelCustomRewardResponse, error) {
-	resp, err := c.get("/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts...)
+func (c *Client) GetCustomRewards(ctx context.Context, params *GetCustomRewardsParams, opts ...Option) (*ChannelCustomRewardResponse, error) {
+	resp, err := c.get(ctx, "/channel_points/custom_rewards", &ManyChannelCustomRewards{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -25,8 +25,8 @@ type BadgeVersion struct {
 	ImageUrl4x string `json:"image_url_4x"`
 }
 
-func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams) (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges", &ManyChatBadge{}, params)
+func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams, opts ...Options) (*GetChatBadgeResponse, error) {
+	resp, err := c.get("/chat/badges", &ManyChatBadge{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams) (*GetChatBadge
 	return channels, nil
 }
 
-func (c *Client) GetGlobalChatBadges() (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges/global", &ManyChatBadge{}, nil)
+func (c *Client) GetGlobalChatBadges(opts ...Options) (*GetChatBadgeResponse, error) {
+	resp, err := c.get("/chat/badges/global", &ManyChatBadge{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ type EmoteImage struct {
 	Url4x string `json:"url_4x"`
 }
 
-func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams) (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes", &ManyEmotes{}, params)
+func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams, opts ...Options) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get("/chat/emotes", &ManyEmotes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +110,8 @@ func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams) (*GetChannelEm
 	return emotes, nil
 }
 
-func (c *Client) GetGlobalEmotes() (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes/global", &ManyEmotes{}, nil)
+func (c *Client) GetGlobalEmotes(opts ...Options) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get("/chat/emotes/global", &ManyEmotes{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -124,8 +124,8 @@ func (c *Client) GetGlobalEmotes() (*GetChannelEmotesResponse, error) {
 }
 
 // GetEmoteSets
-func (c *Client) GetEmoteSets(params *GetEmoteSetsParams) (*GetEmoteSetsResponse, error) {
-	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params)
+func (c *Client) GetEmoteSets(params *GetEmoteSetsParams, opts ...Options) (*GetEmoteSetsResponse, error) {
+	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type GetChatBadgeParams struct {
 	BroadcasterID string `query:"broadcaster_id"`
 }
@@ -25,8 +27,8 @@ type BadgeVersion struct {
 	ImageUrl4x string `json:"image_url_4x"`
 }
 
-func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams, opts ...Options) (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges", &ManyChatBadge{}, params, opts...)
+func (c *Client) GetChannelChatBadges(ctx context.Context, params *GetChatBadgeParams, opts ...Option) (*GetChatBadgeResponse, error) {
+	resp, err := c.get(ctx, "/chat/badges", &ManyChatBadge{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +40,8 @@ func (c *Client) GetChannelChatBadges(params *GetChatBadgeParams, opts ...Option
 	return channels, nil
 }
 
-func (c *Client) GetGlobalChatBadges(opts ...Options) (*GetChatBadgeResponse, error) {
-	resp, err := c.get("/chat/badges/global", &ManyChatBadge{}, nil, opts...)
+func (c *Client) GetGlobalChatBadges(ctx context.Context, opts ...Option) (*GetChatBadgeResponse, error) {
+	resp, err := c.get(ctx, "/chat/badges/global", &ManyChatBadge{}, nil, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +99,8 @@ type EmoteImage struct {
 	Url4x string `json:"url_4x"`
 }
 
-func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams, opts ...Options) (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes", &ManyEmotes{}, params, opts...)
+func (c *Client) GetChannelEmotes(ctx context.Context, params *GetChannelEmotesParams, opts ...Option) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get(ctx, "/chat/emotes", &ManyEmotes{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +112,8 @@ func (c *Client) GetChannelEmotes(params *GetChannelEmotesParams, opts ...Option
 	return emotes, nil
 }
 
-func (c *Client) GetGlobalEmotes(opts ...Options) (*GetChannelEmotesResponse, error) {
-	resp, err := c.get("/chat/emotes/global", &ManyEmotes{}, nil, opts...)
+func (c *Client) GetGlobalEmotes(ctx context.Context, opts ...Option) (*GetChannelEmotesResponse, error) {
+	resp, err := c.get(ctx, "/chat/emotes/global", &ManyEmotes{}, nil, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -124,8 +126,8 @@ func (c *Client) GetGlobalEmotes(opts ...Options) (*GetChannelEmotesResponse, er
 }
 
 // GetEmoteSets
-func (c *Client) GetEmoteSets(params *GetEmoteSetsParams, opts ...Options) (*GetEmoteSetsResponse, error) {
-	resp, err := c.get("/chat/emotes/set", &ManyEmotesWithOwner{}, params, opts...)
+func (c *Client) GetEmoteSets(ctx context.Context, params *GetEmoteSetsParams, opts ...Option) (*GetEmoteSetsResponse, error) {
+	resp, err := c.get(ctx, "/chat/emotes/set", &ManyEmotesWithOwner{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/clips.go
+++ b/clips.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Clip struct {
 	ID              string  `json:"id"`
 	URL             string  `json:"url"`
@@ -43,8 +45,8 @@ type ClipsParams struct {
 }
 
 // GetClips returns information about a specified clip.
-func (c *Client) GetClips(params *ClipsParams, opts ...Options) (*ClipsResponse, error) {
-	resp, err := c.get("/clips", &ManyClips{}, params, opts...)
+func (c *Client) GetClips(ctx context.Context, params *ClipsParams, opts ...Option) (*ClipsResponse, error) {
+	resp, err := c.get(ctx, "/clips", &ManyClips{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +100,8 @@ type CreateClipParams struct {
 // clip was not created and retry Create Clip.
 //
 // Required scope: clips:edit
-func (c *Client) CreateClip(params *CreateClipParams, opts ...Options) (*CreateClipResponse, error) {
-	resp, err := c.post("/clips", &ManyClipEditURLs{}, params, opts...)
+func (c *Client) CreateClip(ctx context.Context, params *CreateClipParams, opts ...Option) (*CreateClipResponse, error) {
+	resp, err := c.post(ctx, "/clips", &ManyClipEditURLs{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/clips.go
+++ b/clips.go
@@ -43,8 +43,8 @@ type ClipsParams struct {
 }
 
 // GetClips returns information about a specified clip.
-func (c *Client) GetClips(params *ClipsParams) (*ClipsResponse, error) {
-	resp, err := c.get("/clips", &ManyClips{}, params)
+func (c *Client) GetClips(params *ClipsParams, opts ...Options) (*ClipsResponse, error) {
+	resp, err := c.get("/clips", &ManyClips{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ type CreateClipParams struct {
 // clip was not created and retry Create Clip.
 //
 // Required scope: clips:edit
-func (c *Client) CreateClip(params *CreateClipParams) (*CreateClipResponse, error) {
-	resp, err := c.post("/clips", &ManyClipEditURLs{}, params)
+func (c *Client) CreateClip(params *CreateClipParams, opts ...Options) (*CreateClipResponse, error) {
+	resp, err := c.post("/clips", &ManyClipEditURLs{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,17 +35,18 @@ go get -u github.com/nicklaw5/helix/v2
 main.go:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     panic(err)
 }
 
-resp, err := client.GetUsers(&helix.UsersParams{
+resp, err := client.GetUsers(context.Background(), &helix.UsersParams{
     IDs:    []string{"26301881", "18074328"},
     Logins: []string{"summit1g", "lirik"},
-})
+)
 if err != nil {
     panic(err)
 }
@@ -82,9 +83,10 @@ Once you have a Client-ID, to create a new client simply the `NewClient` functio
 your client ID as an option. For example:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
@@ -101,10 +103,11 @@ httpClient := &http.Client{
     Timeout: 10 * time.Second,
 }
 
-client, err := helix.NewClient(&helix.Options{
-    ClientID:   "your-client-id",
-    HTTPClient: httpClient,
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithHttpDo(httpClient.Do),
+)
 if err != nil {
     // handle error
 }
@@ -115,20 +118,37 @@ if err != nil {
 Below is a list of all available options that can be passed in when creating a new client:
 
 ```go
-type Options struct {
-    ClientID        string            // Required
-    ClientSecret    string            // Default: empty string
-    AppAccessToken  string            // Default: empty string
-    UserAccessToken string            // Default: empty string
-    UserAgent       string            // Default: empty string
-    RedirectURI     string            // Default: empty string
-    HTTPClient      HTTPClient        // Default: http.DefaultClient
-    RateLimitFunc   RateLimitFunc     // Default: nil
-    APIBaseURL      string            // Default: https://api.twitch.tv/helix
-}
+// REQUIRED
+helix.WithClientID(string)
+
+// OPTIONAL
+helix.WithClientSecret(string)
+
+// OPTIONAL
+helix.WithAppAccessToken(string)
+
+// OPTIONAL
+helix.WithUserAccessToken(string)
+
+// OPTIONAL
+helix.WithUserAgent(string)
+
+// OPTIONAL
+helix.WithRedirectURI(string)
+
+// OPTIONAL
+helix.WithHTTPClient(func(*http.Request) (*http.Response, error) {
+
+})
+
+// OPTIONAL
+helix.WithRateLimitFunc(helix.RateLimitFunc)
+
+// OPTIONAL
+helix.WithAPIBaseURL(string)
 ```
 
-If no custom `http.Client` is provided, `http.DefaultClient` is used by default.
+If no custom HTTP executor is provided, `http.DefaultClient` is used by default.
 
 ## Responses
 
@@ -204,10 +224,11 @@ func rateLimitCallback(lastResponse *helix.Response) error {
     return nil
 }
 
-client, err := helix.NewClient(&helix.Options{
-    ClientID:      "your-client-id",
-    RateLimitFunc: rateLimitCallback,
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    hliex.WithRateLimitFunc(rateLimitCallback),
+)
 if err != nil {
     // handle error
 }
@@ -236,11 +257,12 @@ In order to set the access token for a request, you can either supply it as an o
 or `SetAppAccessToken` methods. For example:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-    AppAccessToken:  "your-app-access-token"
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    WithUserAccessToken("your-user-access-token"),
+    WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }
@@ -251,9 +273,10 @@ if err != nil {
 Or:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
@@ -276,10 +299,11 @@ request. You can do so by passing it through as an option when creating a new cl
 with the `SetUserAgent()` method before sending a request. For example:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:  "your-client-id",
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
     UserAgent: "your-user-agent-value",
-})
+)
 if err != nil {
     // handle error
 }
@@ -290,9 +314,10 @@ if err != nil {
 Alternatively, you can set by calling the `SetUserAgent()` method before sending a request. For example:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:  "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }

--- a/docs/analytics_docs.md
+++ b/docs/analytics_docs.md
@@ -6,16 +6,16 @@ This is an example of how to get the downloadable CSV file containing analytics 
 
 ```go
 client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-})
+    WithClientID("your-client-id"),
+    WithUserAccessToken("your-user-access-token"),
+)
 if err != nil {
     // handle error
 }
 
 gameID := "493057"
 
-resp, err := client.GetGameAnalytics(gameID)
+resp, err := client.GetGameAnalytics(context.Background(), gameID)
 if err != nil {
     // handle error
 }
@@ -26,10 +26,10 @@ fmt.Printf("%+v\n", resp)
 ## Get Extensions Analytics
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    WithClientID("your-client-id"),
+    WithUserAccessToken("your-user-access-token"),
+)
 if err != nil {
     // handle error
 }
@@ -39,7 +39,7 @@ params := helix.ExtensionAnalyticsParams{
     Type:        "overview_v1",
 }
 
-resp, err := client.GetExtensionAnalytics(&params)
+resp, err := client.GetExtensionAnalytics(context.Background(), &params)
 if err != nil {
     // handle error
 }

--- a/docs/authentication_docs.md
+++ b/docs/authentication_docs.md
@@ -9,15 +9,16 @@ can be used to generate access tokens for API consumption. See the Twitch
 [authentication docs](https://dev.twitch.tv/docs/authentication) for more information.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:    "your-client-id",
-    RedirectURI: "https://example.com/auth/callback",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    WithClientID("your-client-id"),
+    WithRedirectURI("https://example.com/auth/callback"),
+)
 if err != nil {
     // handle error
 }
 
-url := client.GetAuthorizationURL(&helix.AuthorizationURLParams{
+url := client.GetAuthorizationURL(context.Background(), &helix.AuthorizationURLParams{
     ResponseType: "code", // or "token"
     Scopes:       []string{"user:read:email"},
     State:        "some-state",
@@ -34,18 +35,18 @@ then be used to submit API requests on behalf of a user. Here's an example of ho
 access token:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:     "your-client-id",
-    ClientSecret: "your-client-secret",
-    RedirectURI:  "https://example.com/auth/callback",
-})
+client, err := helix.NewClient(
+    helix.WithClientID("your-client-id"),
+    helix.WithClientSecret("your-client-secret"),
+    helix.WithRedirectURI("https://example.com/auth/callback"),
+)
 if err != nil {
     // handle error
 }
 
 code := "your-authentication-code"
 
-resp, err := client.RequestUserAccessToken(code)
+resp, err := client.RequestUserAccessToken(context.Background(), code)
 if err != nil {
     // handle error
 }
@@ -61,17 +62,17 @@ client.SetUserAccessToken(resp.Data.AccessToken)
 You can refresh a user access token in the following manner:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:     "your-client-id",
-    ClientSecret: "your-client-secret",
-})
+client, err := helix.NewClient(
+    helix.WithClientID("your-client-id"),
+    helix.WithClientSecret("your-client-secret"),
+)
 if err != nil {
     // handle error
 }
 
 refreshToken := "your-refresh-token"
 
-resp, err := client.RefreshUserAccessToken(refreshToken)
+resp, err := client.RefreshUserAccessToken(context.Background(), refreshToken)
 if err != nil {
     // handle error
 }
@@ -85,15 +86,15 @@ You can revoke a user access token in the following manner:
 
 ```go
 client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
 userAccessToken := client.GetUserAccessToken()
 
-resp, err := client.RevokeUserAccessToken(userAccessToken)
+resp, err := client.RevokeUserAccessToken(context.Background(), userAccessToken)
 if err != nil {
     // handle error
 }
@@ -106,16 +107,16 @@ fmt.Printf("%+v\n", resp)
 You can validate an access token and get token details in the following manner:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
 userAccessToken := client.GetUserAccessToken()
 
-isValid, resp, err := client.ValidateToken(userAccessToken)
+isValid, resp, err := client.ValidateToken(context.Background(), userAccessToken)
 if err != nil {
     // handle error
 }
@@ -133,20 +134,17 @@ Here's an example of how to create an app access token:
 
 ```go
 client, err := helix.NewClient(&helix.Options{
-    ClientID:     "your-client-id",
-    ClientSecret: "your-client-secret",
-})
+    helix.WithClientID("your-client-id"),
+    helix.WithClientSecret("your-client-secret"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.RequestAppAccessToken([]string{"user:read:email"})
+resp, err := client.RequestAppAccessToken(context.Background(), []string{"user:read:email"})
 if err != nil {
     // handle error
 }
 
 fmt.Printf("%+v\n", resp)
-
-// Set the access token on the client
-client.SetAppAccessToken(resp.Data.AccessToken)
 ```

--- a/docs/bits_docs.md
+++ b/docs/bits_docs.md
@@ -5,18 +5,19 @@
 This is an example of how to get the last 20 top bits contributers over the past week.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithUserAccessToken("your-user-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetBitsLeaderboard(&helix.BitsLeaderboardParams{
+resp, err := client.GetBitsLeaderboard(context.Background(), &helix.BitsLeaderboardParams{
     Count:  20,
     Period: "week",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/channels_docs.md
+++ b/docs/channels_docs.md
@@ -5,17 +5,17 @@
 This is an example of how to search channels. Here we are requesting the first two streams from the English language. SearchChannels returns live as well as offline channels.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.SearchChannels(&helix.SearchChannelsParams{
+resp, err := client.SearchChannels(context.Background(), &helix.SearchChannelsParams{
     First: 2,
     Language: []string{"en"},
-})
+)
 if err != nil {
     // handle error
 }
@@ -28,16 +28,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get channel informations.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetChannelInformation(&helix.GetChannelInformationParams{
+resp, err := client.GetChannelInformation(context.Background(), &helix.GetChannelInformationParams{
     BroadcasterID: "123456",
-})
+)
 if err != nil {
     // handle error
 }
@@ -51,20 +51,20 @@ This is an example of how to modify channel informations.
 The `Delay` param is a Twitch Partner feature.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.EditChannelInformation(&helix.EditChannelInformationParams{
+resp, err := client.EditChannelInformation(context.Background(), &helix.EditChannelInformationParams{
     BroadcasterID       : "123456",
     GameID              : "456789",
     BroadcasterLanguage : "en",
     Title               : "Your stream title",
     Delay               : 0,
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/channels_points_docs.md
+++ b/docs/channels_points_docs.md
@@ -5,18 +5,18 @@
 This is an example of how to create a custom reward.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CreateCustomReward(&helix.ChannelCustomRewardsParams{
+resp, err := client.CreateCustomReward(context.Background(), &helix.ChannelCustomRewardsParams{
     BroadcasterID : "145328278",
     Title         : "game analysis 1v1",
     Cost          : 50000,
-})
+)
 if err != nil {
     // handle error
 }
@@ -29,17 +29,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to delete a custom rewards.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.DeleteCustomRewards(&helix.DeleteCustomRewardsParams{
+resp, err := client.DeleteCustomRewards(context.Background(), &helix.DeleteCustomRewardsParams{
     BroadcasterID : "145328278",
     ID            : "84da6b13-efe1-4a82-91d0-25260aeb6a9b",
-})
+)
 if err != nil {
     // handle error
 }
@@ -52,16 +52,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get a custom rewards.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetCustomRewards(&helix.GetCustomRewardsParams{
+resp, err := client.GetCustomRewards(context.Background(), &helix.GetCustomRewardsParams{
     BroadcasterID : "145328278",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/chat_docs.md
+++ b/docs/chat_docs.md
@@ -5,16 +5,16 @@
 This is an example of how to get channel chat badges
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetChannelChatBadges(&helix.GetChatBadgeParams{
+resp, err := client.GetChannelChatBadges(context.Background(), &helix.GetChatBadgeParams{
     BroadcasterID: "145328278",
-})
+)
 if err != nil {
     // handle error
 }
@@ -27,14 +27,14 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get global chat badges
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetGlobalChatBadges()
+resp, err := client.GetGlobalChatBadges(context.Background())
 if err != nil {
     // handle error
 }
@@ -47,16 +47,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get channel emotes
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetChannelEmotes(&helix.GetChannelEmotesParams{
+resp, err := client.GetChannelEmotes(context.Background(), &helix.GetChannelEmotesParams{
     BroadcasterID: "145328278",
-})
+)
 if err != nil {
     // handle error
 }
@@ -69,9 +69,9 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get global emotes
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
@@ -89,16 +89,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get a set of emotes
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetEmoteSets(&helix.GetEmoteSetsParams{
+resp, err := client.GetEmoteSets(context.Background(), &helix.GetEmoteSetsParams{
     EmoteSetIDs: []string{"300678379"},
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/clips_docs.md
+++ b/docs/clips_docs.md
@@ -7,16 +7,17 @@
 This is an example of how to get a multiples clip via their IDs.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetClips(&helix.ClipsParams{
+resp, err := client.GetClips(context.Background(), &helix.ClipsParams{
     IDs: []string{"EncouragingPluckySlothSSSsss", "PatientBlindingChamoisSmoocherZ"},
-})
+)
 if err != nil {
     // handle error
 }
@@ -29,16 +30,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get multiple clips from a single broadcaster.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetClips(&helix.ClipsParams{
+resp, err := client.GetClips(context.Background(), &helix.ClipsParams{
     BroadcasterID: "26490481", // summit1g
-})
+)
 if err != nil {
     // handle error
 }
@@ -51,16 +53,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get multiple clips from a single game.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetClips(&helix.ClipsParams{
+resp, err := client.GetClips(context.Background(), &helix.ClipsParams{
     GameID: "490377", // Sea of Thieves
-})
+)
 if err != nil {
     // handle error
 }
@@ -73,18 +76,19 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to create a clip:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-acceess-token",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithUserAccessToken("your-user-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CreateClip(&helix.CreateClipParams{
+resp, err := client.CreateClip(context.Background(), &helix.CreateClipParams{
     BroadcasterID: "26490481", // summit1g
     HasDelay: true, // optional, defaults to false
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/drops_docs.md
+++ b/docs/drops_docs.md
@@ -7,16 +7,16 @@
 This is an example of how to get entitlements for all users of a game.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetDropsEntitlements(&helix.GetDropEntitlementsParams{
+resp, err := client.GetDropsEntitlements(context.Background(), &helix.GetDropEntitlementsParams{
 	GameID: "your-game-id",
-})
+)
 if err != nil {
     // handle error
 }
@@ -29,16 +29,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get entitlements for a specific user.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetDropsEntitlements(&helix.GetDropEntitlementsParams{
+resp, err := client.GetDropsEntitlements(context.Background(), &helix.GetDropEntitlementsParams{
 	UserID: "your-game-id",
-})
+)
 if err != nil {
     // handle error
 }
@@ -51,19 +51,19 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get multiple pages of entitlement results.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
 // First page 
-resp, err := client.GetDropsEntitlements(&helix.GetDropEntitlementsParams{
+resp, err := client.GetDropsEntitlements(context.Background(), &helix.GetDropEntitlementsParams{
 	GameID: "your-game-id",
     After: "",
     First: 50,
-})
+)
 if err != nil {
     // handle error
 }
@@ -71,11 +71,11 @@ if err != nil {
 fmt.Printf("%+v\n", resp)
 
 // Next page
-resp, err = client.GetDropsEntitlements(&helix.GetDropEntitlementsParams{
+resp, err = client.GetDropsEntitlements(context.Background(), &helix.GetDropEntitlementsParams{
 	GameID: "your-game-id",
     After: resp.Data.Pagination.Cursor,
     First: 50,
-})
+)
 if err != nil {
     // handle error
 }
@@ -88,17 +88,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get entitlements for a specific fulfillment status.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetDropsEntitlements(&helix.GetDropEntitlementsParams{
+resp, err := client.GetDropsEntitlements(context.Background(), &helix.GetDropEntitlementsParams{
 	UserID: "your-game-id",
     FulfillmentStatus: "CLAIMED"
-})
+)
 if err != nil {
     // handle error
 }
@@ -113,17 +113,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to update drops entitlements status.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.UpdateDropsEntitlements(&helix.UpdateDropsEntitlementsParams{
+resp, err := client.UpdateDropsEntitlements(context.Background(), &helix.UpdateDropsEntitlementsParams{
 	EntitlementIDs: ["entitlement-id-1", "entitlement-id-2"],
 	FulfillmentStatus: "FULFILLED",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/entitlement_grants_docs.md
+++ b/docs/entitlement_grants_docs.md
@@ -5,10 +5,10 @@
 This is an example of how to create a new entitlements upload URL endpoint:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:       "your-client-id",
-    AppAccessToken: "your-app-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+    helix.WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }
@@ -16,7 +16,7 @@ if err != nil {
 manifestID := "your-manifest-id"
 entitlementType := "bulk_drops_grant"
 
-resp, err := client.CreateEntitlementsUploadURL(manifestID, entitlementType)
+resp, err := client.CreateEntitlementsUploadURL(context.Background(), manifestID, entitlementType)
 if err != nil {
     // handle error
 }

--- a/docs/eventsub_docs.md
+++ b/docs/eventsub_docs.md
@@ -9,17 +9,17 @@ In contrary to webhooks, eventsub subscriptions do not expire based on time. The
 This is an example of how to get eventsub subscriptions.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-    AppAccessToken: "your-app-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+    helix.WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetEventSubSubscriptions(&helix.EventSubSubscriptionsParams{
+resp, err := client.GetEventSubSubscriptions(context.Background(), &helix.EventSubSubscriptionsParams{
     Status: helix.EventSubStatusEnabled, // This is optional.
-})
+)
 if err != nil {
     // handle error
 }
@@ -33,15 +33,15 @@ To create a subscription call CreateEventSubSubscription with a pointer to a sub
 Within the Transport the only supported Method currently is "webhook". Callback needs to be a https link on port 443. With the secret you can verify if notifications came from twitch. See (#verify-eventSub-notification)
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-    AppAccessToken: "your-app-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+    helix.WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CreateEventSubSubscription(&helix.EventSubSubscription{
+resp, err := client.CreateEventSubSubscription(context.Background(), &helix.EventSubSubscription{
     Type: helix.EventSubTypeChannelFollow,
     Version: "1",
     Condition: helix.EventSubCondition{
@@ -52,7 +52,7 @@ resp, err := client.CreateEventSubSubscription(&helix.EventSubSubscription{
         Callback: "https://example.com/follow",
         Secret: "s3cre7w0rd",
     },
-})
+)
 if err != nil {
     // handle error
 }
@@ -65,10 +65,10 @@ fmt.Printf("%+v\n", resp)
 To delete a subscription you need to call RemoveEventSubSubscription with the subscription id as parameter.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-    AppAccessToken: "your-app-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+    helix.WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }

--- a/docs/extensions_docs.md
+++ b/docs/extensions_docs.md
@@ -27,20 +27,21 @@ Note: Currently only the 'external' role is supported by helix endpoints.
 this is used to set the correct header for any Extension helix requests
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-    ExtensionOpts: helix.ExtensionOptions{
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithUserAccessToken("your-user-access-token"),
+    helix.WithExtensionOptions(helix.ExtensionOptions{
         OwnerUserID: os.Getenv(""),
         Secret: os.Getenv(""),
         ConfigurationVersion:  os.Getenv(""),
         Version: os.Getenv(""),
-    },
+    }),
 })
 
 
 // see docs below to see what pub-sub permissions you can pass 
-claims, err := client.ExtensionCreateClaims(broadcasterID, client.FormBroadcastSendPubSubPermissions(), 0)
+claims, err := client.ExtensionCreateClaims(context.Background(), broadcasterID, client.FormBroadcastSendPubSubPermissions(), 0)
 if err != nil {
     // handle err
 }
@@ -57,21 +58,22 @@ client.SetExtensionSignedJWTToken(jwt)
 
 ```go
 
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-    ExtensionOpts: helix.ExtensionOptions{
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithUserAccessToken("your-user-access-token"),
+    helix.WithExtensionOptions(helix.ExtensionOptions{
         OwnerUserID: os.Getenv("EXT_OWNER_ID"),
         Secret: os.Getenv("EXT_SECRET"),
         ConfigurationVersion:  os.Getenv("EXT_CFG_VERSION"),
         Version: os.Getenv("EXT_VERSION"),
-    },
-})
+    }),
+)
 if err != nil {
     // handle error
 }
 
-claims, err := client.ExtensionCreateClaims(broadcasterID, ExternalRole, FormBroadcastSendPubSubPermissions(), 0)
+claims, err := client.ExtensionCreateClaims(context.Background(), broadcasterID, ExternalRole, FormBroadcastSendPubSubPermissions(), 0)
 if err != nil {
     // handle error
 }
@@ -82,9 +84,9 @@ client.SetExtensionSignedJWTToken(jwt)
 
 params := helix.ExtensionGetConfigurationParams{
     ExtensionID: "some-extension-id",                              // Required
-    Segments:          []helix.ExtensionSegmentType{helix.GlobalSegment}, // Optional
+    Segments:    []helix.ExtensionSegmentType{helix.GlobalSegment}, // Optional
 }
-resp, err := client.GetExtensionConfigurationSegment
+resp, err := client.GetExtensionConfigurationSegment(context.Background(), params)
 if err != nil {
     // handle error
 }
@@ -95,21 +97,22 @@ fmt.Printf("%+v\n", resp)
 ## Get Extension Transactions
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID:        "your-client-id",
-    UserAccessToken: "your-user-access-token",
-})
+client, err := helix.NewClient(
+    context.Background(),
+    helix.WithClientID("your-client-id"),
+    helix.WithUserAccessToken("your-user-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-params := helix.ExtensionTransactionsParams{
+params := &helix.ExtensionTransactionsParams{
     ExtensionID: "some-extension-id",                              // Required
     ID:          []string{"74c52265-e214-48a6-91b9-23b6014e8041"}, // Optional
     First:       1,                                                // Optional
 }
 
-resp, err := client.GetExtensionTransactions(&params)
+resp, err := client.GetExtensionTransactions(context.Background(), params)
 if err != nil {
     // handle error
 }

--- a/docs/games_docs.md
+++ b/docs/games_docs.md
@@ -5,16 +5,16 @@
 This is an example of how to get games.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetGames(&helix.GamesParams{
+resp, err := client.GetGames(context.Background(), &helix.GamesParams{
     Names: []string{"Sea of Thieves", "Fortnite"},
-})
+)
 if err != nil {
     // handle error
 }
@@ -27,16 +27,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get top games.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetTopGames(&helix.TopGamesParams{
+resp, err := client.GetTopGames(context.Background(), &helix.TopGamesParams{
     First: 20,
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/moderation_docs.md
+++ b/docs/moderation_docs.md
@@ -8,17 +8,17 @@ To use this function you need a user access token with the `moderation:read` sco
 This is an example of how to get banned users in a channel.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
     UserAccessToken: "your-user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetBannedUsers(&helix.BannedUsersParams{
+resp, err := client.GetBannedUsers(context.Background(), &helix.BannedUsersParams{
     BroadcasterID: "54946241",
-})
+)
 if err != nil {
     // handle error
 }
@@ -31,19 +31,19 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to manage held automod message in a channel.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
     UserAccessToken: "your-user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.ModerateHeldMessage(&helix.HeldMessageModerationParams{
+resp, err := client.ModerateHeldMessage(context.Background(), &helix.HeldMessageModerationParams{
     UserID : "145328278",
     MsgID  : "19fe2618-df5f-45d3-a210-aeda6f6c6d9e",
     Action : "ALLOW",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/polls_docs.md
+++ b/docs/polls_docs.md
@@ -5,16 +5,16 @@
 This is an example of how to get polls.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetPolls(&helix.PollsParams{
+resp, err := client.GetPolls(context.Background(), &helix.PollsParams{
     BroadcasterID: "145328278",
-})
+)
 if err != nil {
     // handle error
 }
@@ -27,14 +27,14 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to create a poll.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CreatePoll(&helix.CreatePollParams{
+resp, err := client.CreatePoll(context.Background(), &helix.CreatePollParams{
     BroadcasterID: "145328278",
     Title: "Test",
     Choices: []helix.PollChoiceParam{
@@ -42,7 +42,7 @@ resp, err := client.CreatePoll(&helix.CreatePollParams{
         helix.PollChoiceParam{ Title: "choice 2" },
     },
     Duration: 30,
-})
+)
 if err != nil {
     // handle error
 }
@@ -55,18 +55,18 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to end a poll.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.EndPoll(&helix.EndPollParams{
+resp, err := client.EndPoll(context.Background(), &helix.EndPollParams{
     BroadcasterID: "145328278",
     ID: "25b14b42-d4d8-4756-86ce-842bf76f82a0",
     Status: "TERMINATED",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/predictions_docs.md
+++ b/docs/predictions_docs.md
@@ -5,16 +5,16 @@
 This is an example of how to get predictions.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetPredictions(&helix.PredictionsParams{
+resp, err := client.GetPredictions(context.Background(), &helix.PredictionsParams{
     BroadcasterID: "145328278",
-})
+)
 if err != nil {
     // handle error
 }
@@ -27,14 +27,14 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to create a prediction.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CreatePrediction(&helix.CreatePredictionParams{
+resp, err := client.CreatePrediction(context.Background(), &helix.CreatePredictionParams{
     BroadcasterID: "145328278",
     Title: "Test",
     Outcomes: []helix.PredictionChoiceParam{
@@ -42,7 +42,7 @@ resp, err := client.CreatePrediction(&helix.CreatePredictionParams{
         helix.PredictionChoiceParam{ Title: "choice 2" },
     },
     PredictionWindow: 300,
-})
+)
 if err != nil {
     // handle error
 }
@@ -55,19 +55,19 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to end a prediction.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.EndPrediction(&helix.EndPredictionParams{
+resp, err := client.EndPrediction(context.Background(), &helix.EndPredictionParams{
     BroadcasterID: "145328278",
     ID: "c36165d9-d5f5-4f81-ab56-17e7347110c8",
     Status: "RESOLVED",
     WinningOutcomeID: "d0c0194a-6016-4ca3-b8eb-0c61183758ab",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/stream_markers_docs.md
+++ b/docs/stream_markers_docs.md
@@ -7,7 +7,7 @@ the current time. The user needs to be authenticated and requires the
 `user:edit:broadcast` scope. Markers cannot be created in [some cases](https://dev.twitch.tv/docs/api/reference/#create-stream-marker).
 
 ```go
-client, err := helix.NewClient(&helix.Options{
+client, err := helix.NewClient(context.Background()
     ClientID:        "your-client-id",
     UserAccessToken: "your-user-access-token",
 })
@@ -16,10 +16,10 @@ if err != nil {
     // handle error
 }
 
-resp, err := client.CreateStreamMarker(&helix.CreateStreamMarkerParams{
+resp, err := client.CreateStreamMarker(context.Background(), &helix.CreateStreamMarkerParams{
     UserId: "123",
     Description: "a notable moment",
-})
+)
 if err != nil {
     // handle error
 }
@@ -35,7 +35,7 @@ requesting the first two stream markers of a VOD. The authenticated user require
 `user:read:broadcast` scope to be able to request stream markers of this user.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
+client, err := helix.NewClient(context.Background()
     ClientID:        "your-client-id",
     UserAccessToken: "your-user-access-token",
 })
@@ -44,10 +44,10 @@ if err != nil {
     // handle error
 }
 
-resp, err := client.GetStreamMarkers(&helix.StreamMarkersParams{
+resp, err := client.GetStreamMarkers(context.Background(), &helix.StreamMarkersParams{
     First: 2,
     VideoID: "123",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/streams_docs.md
+++ b/docs/streams_docs.md
@@ -5,17 +5,17 @@
 This is an example of how to get streams. Here we are requesting the first two streams from the English language.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetStreams(&helix.StreamsParams{
+resp, err := client.GetStreams(context.Background(), &helix.StreamsParams{
     First: 10,
     Language: []string{"en"},
-})
+)
 if err != nil {
     // handle error
 }
@@ -28,16 +28,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get followed streams.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetFollowedStream(&helix.FollowedStreamsParams{
+resp, err := client.GetFollowedStream(context.Background(), &helix.FollowedStreamsParams{
     UserID: "123456",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/subscriptions_docs.md
+++ b/docs/subscriptions_docs.md
@@ -5,17 +5,17 @@
 This is an example of how to get the broadcaster subscriptions.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
+client, err := helix.NewClient(context.Background()
     ClientID:        "your-client-id",
     UserAccessToken: "your-user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetSubscriptions(&helix.SubscriptionsParams{
+resp, err := client.GetSubscriptions(context.Background(), &helix.SubscriptionsParams{
     BroadcasterID:  "29776980",
-})
+)
 if err != nil {
     // handle error
 }
@@ -28,18 +28,18 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to check if a user is subscribed to a broadcaster.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
+client, err := helix.NewClient(context.Background()
     ClientID:        "your-client-id",
     UserAccessToken: "your-user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.CheckUserSubscription(&helix.UserSubscriptionsParams{
+resp, err := client.CheckUserSubscription(context.Background(), &helix.UserSubscriptionsParams{
     BroadcasterID: "29776980",
     UserID:        "145328278",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/user_extensions.md
+++ b/docs/user_extensions.md
@@ -5,15 +5,15 @@
 This is an example of how to get user extensions
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
     UserAccessToken: "user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUserExtensions()
+resp, err := client.GetUserExtensions(context.Background())
 if err != nil {
     // handle error
 }
@@ -28,15 +28,15 @@ This is an example of how to get active user extensions
 Using UserAccessToken:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
     UserAccessToken: "user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUserActiveExtensions(nil)
+resp, err := client.GetUserActiveExtensions(context.Background(), nil)
 if err != nil {
     // handle error
 }
@@ -47,16 +47,16 @@ fmt.Printf("%+v\n", resp)
 Using user_id query parameter:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUserActiveExtensions(&helix.UserActiveExtensionsParams{
+resp, err := client.GetUserActiveExtensions(context.Background(), &helix.UserActiveExtensionsParams{
     UserID: "user-id"
-})
+)
 if err != nil {
     // handle error
 }
@@ -70,10 +70,10 @@ This is an example of how to update user extensions
 The response format is the same as `GetUserActiveExtensions`
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
     UserAccessToken: "user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
@@ -85,7 +85,7 @@ payload := &helix.UpdateUserExtensionsPayload{
         },
     },
 }
-resp, err := client.UpdateUserExtensions(payload)
+resp, err := client.UpdateUserExtensions(context.Background(), payload)
 if err != nil {
     // handle error
 }

--- a/docs/users_docs.md
+++ b/docs/users_docs.md
@@ -5,17 +5,17 @@
 This is an example of how to get users. Note that you don't need to provide both a list of ids and logins, one or the other will suffice.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUsers(&helix.UsersParams{
+resp, err := client.GetUsers(context.Background(), &helix.UsersParams{
     IDs:    []string{"26301881", "18074328"},
     Logins: []string{"summit1g", "lirik"},
-})
+)
 if err != nil {
     // handle error
 }
@@ -28,17 +28,17 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to update a users description:
 
 ```go
-client, err := helix.NewClient(&helix.Options{
+client, err := helix.NewClient(context.Background()
     ClientID:        "your-client-id",
     UserAccessToken: "your-user-access-token",
-})
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.UpdateUser(&UpdateUserParams{
+resp, err := client.UpdateUser(context.Background(), &UpdateUserParams{
   Description: "New description",
-})
+)
 if err != nil {
     // handle error
 }
@@ -51,16 +51,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get users follows.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUsersFollows(&helix.UsersFollowsParams{
+resp, err := client.GetUsersFollows(context.Background(), &helix.UsersFollowsParams{
     FromID:  "23161357",
-})
+)
 if err != nil {
     // handle error
 }
@@ -73,16 +73,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to get users blocked
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetUsersBlocked(&helix.UsersBlockedParams{
+resp, err := client.GetUsersBlocked(context.Background(), &helix.UsersBlockedParams{
     BroadcasterID: "145328278",
-})
+)
 if err != nil {
     // handle error
 }
@@ -95,18 +95,18 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to block user
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.BlockUser(&helix.BlockUserParams{
+resp, err := client.BlockUser(context.Background(), &helix.BlockUserParams{
     TargetUserID:  "677636701",
     SourceContext: "chat",
     Reason:        "spam",
-})
+)
 if err != nil {
     // handle error
 }
@@ -119,16 +119,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to unblock user
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.UnblockUser(&helix.UnblockUserParams{
+resp, err := client.UnblockUser(context.Background(), &helix.UnblockUserParams{
     TargetUserID: "677636701",
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/videos_docs.md
+++ b/docs/videos_docs.md
@@ -5,20 +5,20 @@
 This is an example of how to get videos.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetVideos(&helix.VideosParams{
+resp, err := client.GetVideos(context.Background(), &helix.VideosParams{
     GameID: "21779",
     Period: "month",
     Type:   "highlight",
     Sort:   "views",
     First:  10,
-})
+)
 if err != nil {
     // handle error
 }
@@ -31,16 +31,16 @@ fmt.Printf("%+v\n", resp)
 This is an example of how to delete videos.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.DeleteVideos(&helix.DeleteVideosParams{
+resp, err := client.DeleteVideos(context.Background(), &helix.DeleteVideosParams{
     IDs: []string{"992599293"},
-})
+)
 if err != nil {
     // handle error
 }

--- a/docs/webhook_docs.md
+++ b/docs/webhook_docs.md
@@ -5,17 +5,17 @@
 This is an example of how to get webhook subscriptions.
 
 ```go
-client, err := helix.NewClient(&helix.Options{
-    ClientID: "your-client-id",
-    AppAccessToken: "your-app-access-token",
-})
+client, err := helix.NewClient(context.Background()
+    helix.WithClientID("your-client-id"),
+    helix.WithAppAccessToken("your-app-access-token"),
+)
 if err != nil {
     // handle error
 }
 
-resp, err := client.GetWebhookSubscriptions(&helix.WebhookSubscriptionsParams{
+resp, err := client.GetWebhookSubscriptions(context.Background(), &helix.WebhookSubscriptionsParams{
     First: 10,
-})
+)
 if err != nil {
     // handle error
 }

--- a/drops.go
+++ b/drops.go
@@ -58,8 +58,8 @@ type UpdateDropsEntitlementsResponse struct {
 // Filtering by FulfillmentStatus returns all of the entitlements with the specified fulfillment status.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams) (*GetDropsEntitlementsResponse, error) {
-	resp, err := c.get("/entitlements/drops", &ManyEntitlementsWithPagination{}, params)
+func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams, opts ...Options) (*GetDropsEntitlementsResponse, error) {
+	resp, err := c.get("/entitlements/drops", &ManyEntitlementsWithPagination{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +81,8 @@ func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams) (*GetDr
 // operation should be retried again later.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) UpdateDropsEntitlements(params *UpdateDropsEntitlementsParams) (*UpdateDropsEntitlementsResponse, error) {
-	resp, err := c.patchAsJSON("/entitlements/drops", &ManyUpdatedEntitlementSet{}, params)
+func (c *Client) UpdateDropsEntitlements(params *UpdateDropsEntitlementsParams, opts ...Options) (*UpdateDropsEntitlementsResponse, error) {
+	resp, err := c.patchAsJSON("/entitlements/drops", &ManyUpdatedEntitlementSet{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/drops.go
+++ b/drops.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type GetDropEntitlementsParams struct {
 	ID                string `query:"id"`
 	UserID            string `query:"user_id"`
@@ -58,8 +60,8 @@ type UpdateDropsEntitlementsResponse struct {
 // Filtering by FulfillmentStatus returns all of the entitlements with the specified fulfillment status.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams, opts ...Options) (*GetDropsEntitlementsResponse, error) {
-	resp, err := c.get("/entitlements/drops", &ManyEntitlementsWithPagination{}, params, opts...)
+func (c *Client) GetDropsEntitlements(ctx context.Context, params *GetDropEntitlementsParams, opts ...Option) (*GetDropsEntitlementsResponse, error) {
+	resp, err := c.get(ctx, "/entitlements/drops", &ManyEntitlementsWithPagination{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +83,8 @@ func (c *Client) GetDropsEntitlements(params *GetDropEntitlementsParams, opts ..
 // operation should be retried again later.
 // Entitlements are digital items that users are entitled to use. Twitch entitlements are granted based on viewership
 // engagement with a content creator, based on the game developers' campaign.
-func (c *Client) UpdateDropsEntitlements(params *UpdateDropsEntitlementsParams, opts ...Options) (*UpdateDropsEntitlementsResponse, error) {
-	resp, err := c.patchAsJSON("/entitlements/drops", &ManyUpdatedEntitlementSet{}, params, opts...)
+func (c *Client) UpdateDropsEntitlements(ctx context.Context, params *UpdateDropsEntitlementsParams, opts ...Option) (*UpdateDropsEntitlementsResponse, error) {
+	resp, err := c.patchAsJSON(ctx, "/entitlements/drops", &ManyUpdatedEntitlementSet{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_codes.go
+++ b/entitlement_codes.go
@@ -38,8 +38,8 @@ type CodeResponse struct {
 // Per https://dev.twitch.tv/docs/api/reference#get-code-status
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch as part of a contracted arrangement.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) GetEntitlementCodeStatus(params *CodesParams) (*CodeResponse, error) {
-	resp, err := c.get("/entitlements/codes", &ManyCodes{}, params)
+func (c *Client) GetEntitlementCodeStatus(params *CodesParams, opts ...Options) (*CodeResponse, error) {
+	resp, err := c.get("/entitlements/codes", &ManyCodes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +55,8 @@ func (c *Client) GetEntitlementCodeStatus(params *CodesParams) (*CodeResponse, e
 // Per https://dev.twitch.tv/docs/api/reference/#redeem-code
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) RedeemEntitlementCode(params *CodesParams) (*CodeResponse, error) {
-	resp, err := c.post("/entitlements/code", &ManyCodes{}, params)
+func (c *Client) RedeemEntitlementCode(params *CodesParams, opts ...Options) (*CodeResponse, error) {
+	resp, err := c.post("/entitlements/code", &ManyCodes{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_codes.go
+++ b/entitlement_codes.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type EntitlementCodeStatus string
 
 const (
@@ -38,8 +40,8 @@ type CodeResponse struct {
 // Per https://dev.twitch.tv/docs/api/reference#get-code-status
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch as part of a contracted arrangement.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) GetEntitlementCodeStatus(params *CodesParams, opts ...Options) (*CodeResponse, error) {
-	resp, err := c.get("/entitlements/codes", &ManyCodes{}, params, opts...)
+func (c *Client) GetEntitlementCodeStatus(ctx context.Context, params *CodesParams, opts ...Option) (*CodeResponse, error) {
+	resp, err := c.get(ctx, "/entitlements/codes", &ManyCodes{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +57,8 @@ func (c *Client) GetEntitlementCodeStatus(params *CodesParams, opts ...Options) 
 // Per https://dev.twitch.tv/docs/api/reference/#redeem-code
 // Access is controlled via an app access token on the calling service. The client ID associated with the app access token must be approved by Twitch.
 // Callers with an app access token are authorized to redeem codes on behalf of any Twitch user account.
-func (c *Client) RedeemEntitlementCode(params *CodesParams, opts ...Options) (*CodeResponse, error) {
-	resp, err := c.post("/entitlements/code", &ManyCodes{}, params, opts...)
+func (c *Client) RedeemEntitlementCode(ctx context.Context, params *CodesParams, opts ...Option) (*CodeResponse, error) {
+	resp, err := c.post(ctx, "/entitlements/code", &ManyCodes{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_grants.go
+++ b/entitlement_grants.go
@@ -22,13 +22,13 @@ type EntitlementsUploadResponse struct {
 // file and notify users that they have an entitlement. Entitlements are digital
 // items that users are entitled to use. Twitch entitlements are granted to users
 // gratis or as part of a purchase on Twitch.
-func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string) (*EntitlementsUploadResponse, error) {
+func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string, opts ...Options) (*EntitlementsUploadResponse, error) {
 	data := &entitlementUploadURLRequest{
 		ManifestID: manifestID,
 		Type:       entitlementType,
 	}
 
-	resp, err := c.post("/entitlements/upload", &ManyEntitlementsUploadURLs{}, data)
+	resp, err := c.post("/entitlements/upload", &ManyEntitlementsUploadURLs{}, data, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/entitlement_grants.go
+++ b/entitlement_grants.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type entitlementUploadURLRequest struct {
 	ManifestID string `query:"manifest_id"`
 	Type       string `query:"type"`
@@ -22,13 +24,13 @@ type EntitlementsUploadResponse struct {
 // file and notify users that they have an entitlement. Entitlements are digital
 // items that users are entitled to use. Twitch entitlements are granted to users
 // gratis or as part of a purchase on Twitch.
-func (c *Client) CreateEntitlementsUploadURL(manifestID, entitlementType string, opts ...Options) (*EntitlementsUploadResponse, error) {
+func (c *Client) CreateEntitlementsUploadURL(ctx context.Context, manifestID, entitlementType string, opts ...Option) (*EntitlementsUploadResponse, error) {
 	data := &entitlementUploadURLRequest{
 		ManifestID: manifestID,
 		Type:       entitlementType,
 	}
 
-	resp, err := c.post("/entitlements/upload", &ManyEntitlementsUploadURLs{}, data, opts...)
+	resp, err := c.post(ctx, "/entitlements/upload", &ManyEntitlementsUploadURLs{}, data, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/eventsub.go
+++ b/eventsub.go
@@ -567,8 +567,8 @@ type EventSubChannelGoalEndEvent struct {
 }
 
 // Get all EventSub Subscriptions
-func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams) (*EventSubSubscriptionsResponse, error) {
-	resp, err := c.get("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params)
+func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams, opts ...Options) (*EventSubSubscriptionsResponse, error) {
+	resp, err := c.get("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -584,9 +584,9 @@ func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams) (
 }
 
 // Remove an EventSub Subscription
-func (c *Client) RemoveEventSubSubscription(id string) (*RemoveEventSubSubscriptionParamsResponse, error) {
+func (c *Client) RemoveEventSubSubscription(id string, opts ...Options) (*RemoveEventSubSubscriptionParamsResponse, error) {
 
-	resp, err := c.delete("/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id})
+	resp, err := c.delete("/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (c *Client) RemoveEventSubSubscription(id string) (*RemoveEventSubSubscript
 }
 
 // Creates an EventSub subscription
-func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription) (*EventSubSubscriptionsResponse, error) {
+func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription, opts ...Options) (*EventSubSubscriptionsResponse, error) {
 	if payload.Transport.Method == "webhook" && !strings.HasPrefix(payload.Transport.Callback, "https://") {
 		return nil, fmt.Errorf("error: callback must use https")
 	}
@@ -613,7 +613,7 @@ func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription) (*Eve
 	if callbackUrl.Port() != "" && callbackUrl.Port() != "443" {
 		return nil, fmt.Errorf("error: callback must use port 443")
 	}
-	resp, err := c.postAsJSON("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload)
+	resp, err := c.postAsJSON("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/eventsub.go
+++ b/eventsub.go
@@ -1,6 +1,7 @@
 package helix
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -567,8 +568,8 @@ type EventSubChannelGoalEndEvent struct {
 }
 
 // Get all EventSub Subscriptions
-func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams, opts ...Options) (*EventSubSubscriptionsResponse, error) {
-	resp, err := c.get("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params, opts...)
+func (c *Client) GetEventSubSubscriptions(ctx context.Context, params *EventSubSubscriptionsParams, opts ...Option) (*EventSubSubscriptionsResponse, error) {
+	resp, err := c.get(ctx, "/eventsub/subscriptions", &ManyEventSubSubscriptions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -584,9 +585,9 @@ func (c *Client) GetEventSubSubscriptions(params *EventSubSubscriptionsParams, o
 }
 
 // Remove an EventSub Subscription
-func (c *Client) RemoveEventSubSubscription(id string, opts ...Options) (*RemoveEventSubSubscriptionParamsResponse, error) {
+func (c *Client) RemoveEventSubSubscription(ctx context.Context, id string, opts ...Option) (*RemoveEventSubSubscriptionParamsResponse, error) {
 
-	resp, err := c.delete("/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id}, opts...)
+	resp, err := c.delete(ctx, "/eventsub/subscriptions", nil, &RemoveEventSubSubscriptionParams{ID: id}, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +598,7 @@ func (c *Client) RemoveEventSubSubscription(id string, opts ...Options) (*Remove
 }
 
 // Creates an EventSub subscription
-func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription, opts ...Options) (*EventSubSubscriptionsResponse, error) {
+func (c *Client) CreateEventSubSubscription(ctx context.Context, payload *EventSubSubscription, opts ...Option) (*EventSubSubscriptionsResponse, error) {
 	if payload.Transport.Method == "webhook" && !strings.HasPrefix(payload.Transport.Callback, "https://") {
 		return nil, fmt.Errorf("error: callback must use https")
 	}
@@ -613,7 +614,7 @@ func (c *Client) CreateEventSubSubscription(payload *EventSubSubscription, opts 
 	if callbackUrl.Port() != "" && callbackUrl.Port() != "443" {
 		return nil, fmt.Errorf("error: callback must use port 443")
 	}
-	resp, err := c.postAsJSON("/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload, opts...)
+	resp, err := c.postAsJSON(ctx, "/eventsub/subscriptions", &ManyEventSubSubscriptions{}, payload, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/eventsub.go
+++ b/eventsub.go
@@ -173,7 +173,7 @@ type EventSubChannelSubscriptionMessageEvent struct {
 	BroadcasterUserName  string          `json:"broadcaster_user_name"`
 	Tier                 string          `json:"tier"`
 	Message              EventSubMessage `json:"message"`
-	CumulativeTotal      int             `json:"cumulative_total"`
+	CumulativeMonths     int             `json:"cumulative_months"`
 	StreakMonths         int             `json:"streak_months"`
 	DurationMonths       int             `json:"duration_months"`
 }

--- a/examples/authorize/README.md
+++ b/examples/authorize/README.md
@@ -1,0 +1,12 @@
+# Authorize Example
+
+## Provisioning Twitch
+
+1. First you must have two factor authentication enabled to register an application in the developer console.
+1. Goto https://dev.twitch.tv/console/apps/create
+1. Fill in a name of your choice.
+1. Add a OAuth redirect URL to `http://localhost:8000/oauth/callback`.
+1. Set the category as `Application Integration`
+1. Click the create.
+1. Copy the client ID and the client secret as you'll need them next.
+

--- a/examples/authorize/main.go
+++ b/examples/authorize/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/nicklaw5/helix/v2"
+)
+
+var (
+	client *helix.Client
+)
+
+func httpServer() (<-chan string, func()) {
+	nl, err := net.Listen("tcp", ":8000")
+	if err != nil {
+		log.Fatal("unable to listen on port 8000", err)
+	}
+
+	out := make(chan string)
+	srv := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			code := r.URL.Query().Get("code")
+
+			if code == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			out <- code
+			w.Header().Add("content-type", "text/html")
+			_, _ = w.Write([]byte("<h1>You may close this window and return to the terminal.</h1>"))
+		}),
+	}
+
+	go srv.Serve(nl)
+
+	return out, func() { srv.Close() }
+}
+
+func getAccessToken(ctx context.Context) (string, error) {
+	cp, close := httpServer()
+	defer close()
+
+	url := client.GetAuthorizationURL(ctx, &helix.AuthorizationURLParams{
+		ResponseType: "code",
+		Scopes: []string{
+			"user:read:email",
+		},
+	})
+
+	fmt.Printf("Please open the following link in your browser: %s\n", url)
+
+	select {
+	case code := <-cp:
+		fmt.Printf("code: %v\n", code)
+		tok, err := client.RequestUserAccessToken(ctx, code)
+		if err != nil {
+			return "", fmt.Errorf("unable to get access token %w", err)
+		}
+
+		return tok.Data.AccessToken, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func main() {
+	clientId := flag.String("client-id", "", "The client id.")
+	clientSecret := flag.String("client-secret", "", "The client secret.")
+
+	flag.Parse()
+
+	if *clientId == "" || *clientSecret == "" {
+		log.Fatal("you must specify --client-id and --client-secret")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, err := helix.NewClient(
+		ctx,
+		helix.WithClientID(*clientId),
+		helix.WithClientSecret(*clientSecret),
+		helix.WithRedirectURI("http://localhost:8000/oauth/callback"),
+	)
+	if err != nil {
+		log.Fatal("unable to build client", err)
+	}
+	client = c
+
+	accessToken, err := getAccessToken(ctx)
+	if err != nil {
+		log.Fatal("unable to get access token", err)
+	}
+
+	_, u, err := c.ValidateToken(ctx, accessToken)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Logged in user ID: %s\n", u.Data.UserID)
+}

--- a/extension_configuration.go
+++ b/extension_configuration.go
@@ -63,7 +63,7 @@ type ExtensionSetConfigurationResponse struct {
 }
 
 // https://dev.twitch.tv/docs/extensions/reference/#set-extension-configuration-segment
-func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationParams) (*ExtensionSetConfigurationResponse, error) {
+func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationParams, opts ...Options) (*ExtensionSetConfigurationResponse, error) {
 	if params.BroadcasterID != "" {
 		switch params.Segment {
 		case ExtensionConfigurationDeveloperSegment, ExtensionConfigrationBroadcasterSegment:
@@ -72,7 +72,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 		}
 	}
 
-	resp, err := c.putAsJSON("/extensions/configurations", &ManyPolls{}, params)
+	resp, err := c.putAsJSON("/extensions/configurations", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 	return setExtCnfgResp, nil
 }
 
-func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurationParams) (*ExtensionGetConfigurationSegmentResponse, error) {
+func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurationParams, opts ...Options) (*ExtensionGetConfigurationSegmentResponse, error) {
 
 	if params.BroadcasterID != "" {
 		for _, segment := range params.Segments {
@@ -95,7 +95,7 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 		}
 	}
 
-	resp, err := c.get("/extensions/configurations", &ManyExtensionConfigurationSegments{}, params)
+	resp, err := c.get("/extensions/configurations", &ManyExtensionConfigurationSegments{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +107,9 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 	return extCfgSegResp, nil
 }
 
-func (c *Client) SetExtensionRequiredConfiguration(params *ExtensionSetRequiredConfigurationParams) (*ExtensionSetRequiredConfigurationResponse, error) {
+func (c *Client) SetExtensionRequiredConfiguration(params *ExtensionSetRequiredConfigurationParams, opts ...Options) (*ExtensionSetRequiredConfigurationResponse, error) {
 
-	resp, err := c.putAsJSON("/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params)
+	resp, err := c.putAsJSON("/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_configuration.go
+++ b/extension_configuration.go
@@ -1,6 +1,9 @@
 package helix
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // SegmentType A segment configuration type
 type ExtensionSegmentType string
@@ -63,7 +66,7 @@ type ExtensionSetConfigurationResponse struct {
 }
 
 // https://dev.twitch.tv/docs/extensions/reference/#set-extension-configuration-segment
-func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationParams, opts ...Options) (*ExtensionSetConfigurationResponse, error) {
+func (c *Client) SetExtensionSegmentConfig(ctx context.Context, params *ExtensionSetConfigurationParams, opts ...Option) (*ExtensionSetConfigurationResponse, error) {
 	if params.BroadcasterID != "" {
 		switch params.Segment {
 		case ExtensionConfigurationDeveloperSegment, ExtensionConfigrationBroadcasterSegment:
@@ -72,7 +75,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 		}
 	}
 
-	resp, err := c.putAsJSON("/extensions/configurations", &ManyPolls{}, params, opts...)
+	resp, err := c.putAsJSON(ctx, "/extensions/configurations", &ManyPolls{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +86,7 @@ func (c *Client) SetExtensionSegmentConfig(params *ExtensionSetConfigurationPara
 	return setExtCnfgResp, nil
 }
 
-func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurationParams, opts ...Options) (*ExtensionGetConfigurationSegmentResponse, error) {
+func (c *Client) GetExtensionConfigurationSegment(ctx context.Context, params *ExtensionGetConfigurationParams, opts ...Option) (*ExtensionGetConfigurationSegmentResponse, error) {
 
 	if params.BroadcasterID != "" {
 		for _, segment := range params.Segments {
@@ -95,7 +98,7 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 		}
 	}
 
-	resp, err := c.get("/extensions/configurations", &ManyExtensionConfigurationSegments{}, params, opts...)
+	resp, err := c.get(ctx, "/extensions/configurations", &ManyExtensionConfigurationSegments{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +110,9 @@ func (c *Client) GetExtensionConfigurationSegment(params *ExtensionGetConfigurat
 	return extCfgSegResp, nil
 }
 
-func (c *Client) SetExtensionRequiredConfiguration(params *ExtensionSetRequiredConfigurationParams, opts ...Options) (*ExtensionSetRequiredConfigurationResponse, error) {
+func (c *Client) SetExtensionRequiredConfiguration(ctx context.Context, params *ExtensionSetRequiredConfigurationParams, opts ...Option) (*ExtensionSetRequiredConfigurationResponse, error) {
 
-	resp, err := c.putAsJSON("/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params, opts...)
+	resp, err := c.putAsJSON(ctx, "/extensions/configurations/required_configuration", &ExtensionSetRequiredConfigurationResponse{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_jwt.go
+++ b/extension_jwt.go
@@ -74,7 +74,7 @@ func (c *Client) ExtensionCreateClaims(
 	}
 
 	claims := &TwitchJWTClaims{
-		UserID:      c.opts.ExtensionOpts.OwnerUserID,
+		UserID:      c.opts.extensionOpts.OwnerUserID,
 		ChannelID:   params.ChannelID,
 		Role:        ExternalRole,
 		Permissions: params.PubSub,
@@ -96,7 +96,7 @@ func (c *Client) ExtensionJWTSign(claims *TwitchJWTClaims) (tokenString string, 
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
-	key, err := base64.StdEncoding.DecodeString(c.opts.ExtensionOpts.Secret)
+	key, err := base64.StdEncoding.DecodeString(c.opts.extensionOpts.Secret)
 	if err != nil {
 		return
 	}
@@ -127,7 +127,7 @@ func (c *Client) ExtensionJWTVerify(token string) (claims *TwitchJWTClaims, err 
 			return nil, fmt.Errorf("Unexpected signing method: %s", tkn.Header["alg"])
 		}
 
-		key, err := base64.StdEncoding.DecodeString(c.opts.ExtensionOpts.Secret)
+		key, err := base64.StdEncoding.DecodeString(c.opts.extensionOpts.Secret)
 
 		if err != nil {
 			return nil, err
@@ -148,11 +148,11 @@ func (c *Client) ExtensionJWTVerify(token string) (claims *TwitchJWTClaims, err 
 }
 
 func (c *Client) validateExtensionOpts() error {
-	if c.opts.ExtensionOpts.OwnerUserID == "" {
+	if c.opts.extensionOpts.OwnerUserID == "" {
 		return fmt.Errorf("extension owner id is empty")
 	}
 
-	if c.opts.ExtensionOpts.Secret == "" {
+	if c.opts.extensionOpts.Secret == "" {
 		return fmt.Errorf("extension secret is empty")
 	}
 

--- a/extension_pubsub.go
+++ b/extension_pubsub.go
@@ -61,8 +61,8 @@ type ExtensionSendPubSubMessageResponse struct {
 	ResponseCommon
 }
 
-func (c *Client) SendExtensionPubSubMessage(params *ExtensionSendPubSubMessageParams) (*ExtensionSendPubSubMessageResponse, error) {
-	resp, err := c.postAsJSON("/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params)
+func (c *Client) SendExtensionPubSubMessage(params *ExtensionSendPubSubMessageParams, opts ...Options) (*ExtensionSendPubSubMessageResponse, error) {
+	resp, err := c.postAsJSON("/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_pubsub.go
+++ b/extension_pubsub.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 // PublishType The Pub/Sub broadcast type
 type ExtensionPubSubPublishType string
 
@@ -61,8 +63,8 @@ type ExtensionSendPubSubMessageResponse struct {
 	ResponseCommon
 }
 
-func (c *Client) SendExtensionPubSubMessage(params *ExtensionSendPubSubMessageParams, opts ...Options) (*ExtensionSendPubSubMessageResponse, error) {
-	resp, err := c.postAsJSON("/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params, opts...)
+func (c *Client) SendExtensionPubSubMessage(ctx context.Context, params *ExtensionSendPubSubMessageParams, opts ...Option) (*ExtensionSendPubSubMessageResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/extensions/pubsub", &ExtensionSendPubSubMessageResponse{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_secrets.go
+++ b/extension_secrets.go
@@ -39,8 +39,8 @@ type GetExtensionSecretParams struct {
 	ExtensionID string `query:"extension_id"`
 }
 
-func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams) (*ExtensionSecretCreationResponse, error) {
-	resp, err := c.post("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params)
+func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams, opts ...Options) (*ExtensionSecretCreationResponse, error) {
+	resp, err := c.post("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams) (*
 	return events, nil
 }
 
-func (c *Client) GetExtensionSecrets(params *GetExtensionSecretParams) (*GetExtensionSecretResponse, error) {
-	resp, err := c.postAsJSON("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params)
+func (c *Client) GetExtensionSecrets(params *GetExtensionSecretParams, opts ...Options) (*GetExtensionSecretResponse, error) {
+	resp, err := c.postAsJSON("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extension_secrets.go
+++ b/extension_secrets.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 // GetExtensionSecretResponse response structure received
 // when generating or querying for generated secrets
 type ExtensionSecretCreationResponse struct {
@@ -39,8 +41,8 @@ type GetExtensionSecretParams struct {
 	ExtensionID string `query:"extension_id"`
 }
 
-func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams, opts ...Options) (*ExtensionSecretCreationResponse, error) {
-	resp, err := c.post("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
+func (c *Client) CreateExtensionSecret(ctx context.Context, params *ExtensionSecretCreationParams, opts ...Option) (*ExtensionSecretCreationResponse, error) {
+	resp, err := c.post(ctx, "/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +54,8 @@ func (c *Client) CreateExtensionSecret(params *ExtensionSecretCreationParams, op
 	return events, nil
 }
 
-func (c *Client) GetExtensionSecrets(params *GetExtensionSecretParams, opts ...Options) (*GetExtensionSecretResponse, error) {
-	resp, err := c.postAsJSON("/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts...)
+func (c *Client) GetExtensionSecrets(ctx context.Context, params *GetExtensionSecretParams, opts ...Option) (*GetExtensionSecretResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/extensions/jwt/secrets", &ManyExtensionSecrets{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions.go
+++ b/extensions.go
@@ -1,6 +1,9 @@
 package helix
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type ExtensionTransaction struct {
 	ID               string `json:"id"`
@@ -83,8 +86,8 @@ type ExtensionLiveChannelsResponse struct {
 // exchanging Bits for an in-Extension digital good.
 //
 // See https://dev.twitch.tv/docs/api/reference/#get-extension-transactions
-func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams, opts ...Options) (*ExtensionTransactionsResponse, error) {
-	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params, opts...)
+func (c *Client) GetExtensionTransactions(ctx context.Context, params *ExtensionTransactionsParams, opts ...Option) (*ExtensionTransactionsResponse, error) {
+	resp, err := c.get(ctx, "/extensions/transactions", &ManyExtensionTransactions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +104,7 @@ func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams, o
 // The author of the message is the Extension name.
 //
 // see https://dev.twitch.tv/docs/api/reference#send-extension-chat-message
-func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams, opts ...Options) (*ExtensionSendChatMessageResponse, error) {
+func (c *Client) SendExtensionChatMessage(ctx context.Context, params *ExtensionSendChatMessageParams, opts ...Option) (*ExtensionSendChatMessageResponse, error) {
 
 	if len(params.Text) > 280 {
 		return nil, fmt.Errorf("error: chat message length exceeds 280 characters")
@@ -111,7 +114,7 @@ func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams
 		return nil, fmt.Errorf("error: broadcaster ID must be specified")
 	}
 
-	resp, err := c.postAsJSON("/extensions/chat", &ExtensionSendChatMessageResponse{}, params, opts...)
+	resp, err := c.postAsJSON(ctx, "/extensions/chat", &ExtensionSendChatMessageResponse{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +125,12 @@ func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams
 	return sndExtMsgResp, nil
 }
 
-func (c *Client) GetExtensionLiveChannels(params *ExtensionLiveChannelsParams) (*ExtensionLiveChannelsResponse, error) {
-
+func (c *Client) GetExtensionLiveChannels(ctx context.Context, params *ExtensionLiveChannelsParams, opts ...Option) (*ExtensionLiveChannelsResponse, error) {
 	if params.ExtensionID == "" {
 		return nil, fmt.Errorf("error: extension ID must be specified")
 	}
 
-	resp, err := c.get("/extensions/live", &ManyExtensionLiveChannels{}, params)
+	resp, err := c.get(ctx, "/extensions/live", &ManyExtensionLiveChannels{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions.go
+++ b/extensions.go
@@ -83,8 +83,8 @@ type ExtensionLiveChannelsResponse struct {
 // exchanging Bits for an in-Extension digital good.
 //
 // See https://dev.twitch.tv/docs/api/reference/#get-extension-transactions
-func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams) (*ExtensionTransactionsResponse, error) {
-	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params)
+func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams, opts ...Options) (*ExtensionTransactionsResponse, error) {
+	resp, err := c.get("/extensions/transactions", &ManyExtensionTransactions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *Client) GetExtensionTransactions(params *ExtensionTransactionsParams) (
 // The author of the message is the Extension name.
 //
 // see https://dev.twitch.tv/docs/api/reference#send-extension-chat-message
-func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams) (*ExtensionSendChatMessageResponse, error) {
+func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams, opts ...Options) (*ExtensionSendChatMessageResponse, error) {
 
 	if len(params.Text) > 280 {
 		return nil, fmt.Errorf("error: chat message length exceeds 280 characters")
@@ -111,7 +111,7 @@ func (c *Client) SendExtensionChatMessage(params *ExtensionSendChatMessageParams
 		return nil, fmt.Errorf("error: broadcaster ID must be specified")
 	}
 
-	resp, err := c.postAsJSON("/extensions/chat", &ExtensionSendChatMessageResponse{}, params)
+	resp, err := c.postAsJSON("/extensions/chat", &ExtensionSendChatMessageResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -100,6 +100,69 @@ func TestGetExtensionTransactions(t *testing.T) {
 	}
 }
 
+func TestGetExtensionLiveChannels(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode     int
+		options        *Options
+		params         *ExtensionLiveChannelsParams
+		respBody       string
+		expectedErrMsg string
+	}{
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&ExtensionLiveChannelsParams{ExtensionID: "some-extension-id"},
+			`{ "data": [{ "broadcaster_id": "121086094", "broadcaster_name": "khaizer93", "game_name": "Art", "game_id": "509660", "title": "random artstream sketching Kiryu COCO" }, { "broadcaster_id": "165951395", "broadcaster_name": "MelloTodd", "game_name": "Jackbox Party Packs", "game_id": "493174", "title": "[OPEN] WInner Choses Next Game (1-8) | !jackbox !uptime #envtuber" }, { "broadcaster_id": "21724294", "broadcaster_name": "Mahoog47", "game_name": "Escape from Tarkov", "game_id": "491931", "title": "LVL 39| The holy relic Ash-12 has been acquired" }, { "broadcaster_id": "253663808", "broadcaster_name": "MrHatcher_", "game_name": "Dota 2", "game_id": "29595", "title": "Road to 53/55 followers! Dota 2 Ranked 1k mmr (british/filipino)" }, { "broadcaster_id": "245641098", "broadcaster_name": "ChoKoii", "game_name": "Escape from Tarkov", "game_id": "491931", "title": "First Drops Enabled Stream? | Labs Main | 1 Follower=5 push-ups" }, { "broadcaster_id": "268444856", "broadcaster_name": "D4RK_5KY", "game_name": "Always On", "game_id": "499973", "title": "24/7 FULLSEND HOST RAFFLE - Need THAT #SUPPORT!? #Affiliate PUSH!? Try Your LUCK \u0026 WIN The Raffle!" }, { "broadcaster_id": "42871388", "broadcaster_name": "mieudiary", "game_name": "Stardew Valley", "game_id": "490744", "title": "I'm very sleepy but let's farm | !melaomi" }, { "broadcaster_id": "429972112", "broadcaster_name": "andy_gra", "game_name": "twitch", "game_id": "", "title": "wbijaj smialo :)" }, { "broadcaster_id": "486154226", "broadcaster_name": "mrboone521", "game_name": "Escape from Tarkov", "game_id": "491931", "title": "TARK TARK offline and scav runs" }, { "broadcaster_id": "503028811", "broadcaster_name": "Uwlsy2k", "game_name": "Fortnite", "game_id": "33214", "title": "Bot Zonewars?! Join up and chat " }, { "broadcaster_id": "520878515", "broadcaster_name": "me_fon", "game_name": "Teamfight Tactics", "game_id": "513143", "title": "Ranking up in TFT Mob" }, { "broadcaster_id": "521301629", "broadcaster_name": "acrolic_", "game_name": "Apex Legends", "game_id": "511224", "title": "Come say hi! |road to 50 followers | song choices" }, { "broadcaster_id": "54270050", "broadcaster_name": "ELIASS_1", "game_name": "SCUM", "game_id": "495811", "title": "walking simulator 2022 | !setup | !sleep  | 386/400 followers | " }, { "broadcaster_id": "611701485", "broadcaster_name": "Semmy_22", "game_name": "Overwatch", "game_id": "488552", "title": "Support slave at your service " }, { "broadcaster_id": "63501619", "broadcaster_name": "KittySinisterr", "game_name": "Fortnite", "game_id": "33214", "title": "Winterfest challenges" }, { "broadcaster_id": "625059457", "broadcaster_name": "unisclan", "game_name": "Battlefield 2042", "game_id": "514974", "title": "crazy gameplay tanks   will not live " }, { "broadcaster_id": "604281079", "broadcaster_name": "viperarishyt", "game_name": "FIFA 22", "game_id": "1869092879", "title": "Grab Your Breakfast and Join me. Lets chat :-)" }, { "broadcaster_id": "666411722", "broadcaster_name": "SarahBree", "game_name": "Apex Legends", "game_id": "511224", "title": "Winter express only before it goes away :'(" }, { "broadcaster_id": "647613771", "broadcaster_name": "batbat0508", "game_name": "Battlefield 4", "game_id": "66402", "title": "( GOVS ) ~Fr-En ~ rules (LOCKER)" }, { "broadcaster_id": "653487605", "broadcaster_name": "honka2019", "game_name": "Identity V", "game_id": "508662", "title": "JPN♡本日も23:30頃までまったりプレイ⚠️mobile play" }], "pagination": "YVc1emRHRnNiQ00yTXpVd01UWXhPVHBsT1ROalpqZzNNekJ1WkRFeGVqZG5aWEJyYkhreVozSjVOV3QyT0dzNjoz" }`,		"",
+		},
+		{
+			http.StatusOK,
+			&Options{ClientID: "my-client-id"},
+			&ExtensionLiveChannelsParams{ExtensionID: "", First: 2},
+			`{"error":"Bad Request","status":400,"message":"missing extension id"}`,
+			"error: extension ID must be specified",
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newMockClient(testCase.options, newMockHandler(testCase.statusCode, testCase.respBody, nil))
+
+		resp, err := c.GetExtensionLiveChannels(testCase.params)
+		if err != nil {
+			if err.Error() == testCase.expectedErrMsg {
+				continue
+			}
+
+			t.Error(err)
+		}
+
+		if resp.StatusCode != testCase.statusCode {
+			t.Errorf("expected status code to be \"%d\", got \"%d\"", testCase.statusCode, resp.StatusCode)
+		}
+
+		if resp.StatusCode == http.StatusForbidden {
+			if resp.Error != "Forbidden" {
+				t.Errorf("expected error to be \"%s\", got \"%s\"", "Bad Request", resp.Error)
+			}
+
+			if resp.ErrorStatus != http.StatusForbidden {
+				t.Errorf("expected error status to be \"%d\", got \"%d\"", http.StatusForbidden, resp.ErrorStatus)
+			}
+
+			if resp.ErrorMessage != testCase.expectedErrMsg {
+				t.Errorf("expected error message to be \"%s\", got \"%s\"", testCase.expectedErrMsg, resp.ErrorMessage)
+			}
+
+			continue
+		}
+
+		if testCase.params.First != 0 && testCase.params.First != len(resp.Data.LiveChannels) {
+			t.Errorf("expected %d transactions, got %d", testCase.params.First, len(resp.Data.LiveChannels))
+		}
+	}
+}
+
 func TestExtensionSendChatMessage(t *testing.T) {
 	t.Parallel()
 

--- a/games.go
+++ b/games.go
@@ -20,8 +20,8 @@ type GamesParams struct {
 	Names []string `query:"name"` // Limit 100
 }
 
-func (c *Client) GetGames(params *GamesParams) (*GamesResponse, error) {
-	resp, err := c.get("/games", &ManyGames{}, params)
+func (c *Client) GetGames(params *GamesParams, opts ...Options) (*GamesResponse, error) {
+	resp, err := c.get("/games", &ManyGames{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +49,8 @@ type TopGamesResponse struct {
 	Data ManyGamesWithPagination
 }
 
-func (c *Client) GetTopGames(params *TopGamesParams) (*TopGamesResponse, error) {
-	resp, err := c.get("/games/top", &ManyGamesWithPagination{}, params)
+func (c *Client) GetTopGames(params *TopGamesParams, opts ...Options) (*TopGamesResponse, error) {
+	resp, err := c.get("/games/top", &ManyGamesWithPagination{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/games.go
+++ b/games.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Game struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
@@ -20,8 +22,8 @@ type GamesParams struct {
 	Names []string `query:"name"` // Limit 100
 }
 
-func (c *Client) GetGames(params *GamesParams, opts ...Options) (*GamesResponse, error) {
-	resp, err := c.get("/games", &ManyGames{}, params, opts...)
+func (c *Client) GetGames(ctx context.Context, params *GamesParams, opts ...Option) (*GamesResponse, error) {
+	resp, err := c.get(ctx, "/games", &ManyGames{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +51,8 @@ type TopGamesResponse struct {
 	Data ManyGamesWithPagination
 }
 
-func (c *Client) GetTopGames(params *TopGamesParams, opts ...Options) (*TopGamesResponse, error) {
-	resp, err := c.get("/games/top", &ManyGamesWithPagination{}, params, opts...)
+func (c *Client) GetTopGames(ctx context.Context, params *TopGamesParams, opts ...Option) (*TopGamesResponse, error) {
+	resp, err := c.get(ctx, "/games/top", &ManyGamesWithPagination{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/goals.go
+++ b/goals.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Goal struct {
 	ID               string `json:"id"`
 	BroadcasterID    string `json:"broadcaster_id"`
@@ -27,8 +29,8 @@ type GetCreatorGoalsParams struct {
 }
 
 // Required scope: channel:read:goals
-func (c *Client) GetCreatorGoals(payload *GetCreatorGoalsParams, opts ...Options) (*CreatorGoalsResponse, error) {
-	resp, err := c.get("/goals", &ManyGoals{}, payload, opts...)
+func (c *Client) GetCreatorGoals(ctx context.Context, payload *GetCreatorGoalsParams, opts ...Option) (*CreatorGoalsResponse, error) {
+	resp, err := c.get(ctx, "/goals", &ManyGoals{}, payload, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/goals.go
+++ b/goals.go
@@ -27,8 +27,8 @@ type GetCreatorGoalsParams struct {
 }
 
 // Required scope: channel:read:goals
-func (c *Client) GetCreatorGoals(payload *GetCreatorGoalsParams) (*CreatorGoalsResponse, error) {
-	resp, err := c.get("/goals", &ManyGoals{}, payload)
+func (c *Client) GetCreatorGoals(payload *GetCreatorGoalsParams, opts ...Options) (*CreatorGoalsResponse, error) {
+	resp, err := c.get("/goals", &ManyGoals{}, payload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/helix_test.go
+++ b/helix_test.go
@@ -184,8 +184,8 @@ func TestRatelimitCallback(t *testing.T) {
 		ClientID: "my-client-id",
 	}
 
-	c = newMockClient(options2, newMockHandler(http.StatusOK, respBody2, nil))
-	_, err := c.GetStreams(&StreamsParams{})
+	cOK := newMockClient(options2, newMockHandler(http.StatusOK, respBody2, nil))
+	_, err := cOK.GetStreams(&StreamsParams{})
 	if err != nil {
 		t.Errorf("Did not expect error, got \"%s\"", err.Error())
 	}

--- a/hype_train.go
+++ b/hype_train.go
@@ -45,8 +45,8 @@ type HypeTrainEventsParams struct {
 }
 
 // Required scope: channel:read:hype_train
-func (c *Client) GetHypeTrainEvents(params *HypeTrainEventsParams) (*HypeTrainEventsResponse, error) {
-	resp, err := c.get("/hypetrain/events", &ManyHypeTrainEvents{}, params)
+func (c *Client) GetHypeTrainEvents(params *HypeTrainEventsParams, opts ...Options) (*HypeTrainEventsResponse, error) {
+	resp, err := c.get("/hypetrain/events", &ManyHypeTrainEvents{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/hype_train.go
+++ b/hype_train.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type HypeTrainContribuition struct {
 	Total int64  `json:"total"`
 	Type  string `json:"type"`
@@ -45,8 +47,8 @@ type HypeTrainEventsParams struct {
 }
 
 // Required scope: channel:read:hype_train
-func (c *Client) GetHypeTrainEvents(params *HypeTrainEventsParams, opts ...Options) (*HypeTrainEventsResponse, error) {
-	resp, err := c.get("/hypetrain/events", &ManyHypeTrainEvents{}, params, opts...)
+func (c *Client) GetHypeTrainEvents(ctx context.Context, params *HypeTrainEventsParams, opts ...Option) (*HypeTrainEventsResponse, error) {
+	resp, err := c.get(ctx, "/hypetrain/events", &ManyHypeTrainEvents{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation.go
+++ b/moderation.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 // ExpiresAt must be parsed manually since an empty string means perma ban
 type Ban struct {
 	UserID    string `json:"user_id"`
@@ -29,8 +31,8 @@ type BannedUsersParams struct {
 // GetBannedUsers returns all banned and timed-out users in a channel.
 //
 // Required scope: moderation:read
-func (c *Client) GetBannedUsers(params *BannedUsersParams, opts ...Options) (*BannedUsersResponse, error) {
-	resp, err := c.get("/moderation/banned", &ManyBans{}, params, opts...)
+func (c *Client) GetBannedUsers(ctx context.Context, params *BannedUsersParams, opts ...Option) (*BannedUsersResponse, error) {
+	resp, err := c.get(ctx, "/moderation/banned", &ManyBans{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation.go
+++ b/moderation.go
@@ -29,8 +29,8 @@ type BannedUsersParams struct {
 // GetBannedUsers returns all banned and timed-out users in a channel.
 //
 // Required scope: moderation:read
-func (c *Client) GetBannedUsers(params *BannedUsersParams) (*BannedUsersResponse, error) {
-	resp, err := c.get("/moderation/banned", &ManyBans{}, params)
+func (c *Client) GetBannedUsers(params *BannedUsersParams, opts ...Options) (*BannedUsersResponse, error) {
+	resp, err := c.get("/moderation/banned", &ManyBans{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation_automod.go
+++ b/moderation_automod.go
@@ -11,8 +11,8 @@ type HeldMessageModerationParams struct {
 }
 
 // Required scope: moderator:manage:automod
-func (c *Client) ModerateHeldMessage(params *HeldMessageModerationParams) (*HeldMessageModerationResponse, error) {
-	resp, err := c.postAsJSON("/moderation/automod/message", nil, params)
+func (c *Client) ModerateHeldMessage(params *HeldMessageModerationParams, opts ...Options) (*HeldMessageModerationResponse, error) {
+	resp, err := c.postAsJSON("/moderation/automod/message", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/moderation_automod.go
+++ b/moderation_automod.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type HeldMessageModerationResponse struct {
 	ResponseCommon
 }
@@ -11,8 +13,8 @@ type HeldMessageModerationParams struct {
 }
 
 // Required scope: moderator:manage:automod
-func (c *Client) ModerateHeldMessage(params *HeldMessageModerationParams, opts ...Options) (*HeldMessageModerationResponse, error) {
-	resp, err := c.postAsJSON("/moderation/automod/message", nil, params, opts...)
+func (c *Client) ModerateHeldMessage(ctx context.Context, params *HeldMessageModerationParams, opts ...Option) (*HeldMessageModerationResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/moderation/automod/message", nil, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/polls.go
+++ b/polls.go
@@ -48,8 +48,8 @@ type GetPollsResponse struct {
 }
 
 // Required scope: channel:read:polls
-func (c *Client) GetPolls(params *PollsParams) (*PollsResponse, error) {
-	resp, err := c.get("/polls", &ManyPolls{}, params)
+func (c *Client) GetPolls(params *PollsParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.get("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +78,8 @@ type PollChoiceParam struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) CreatePoll(params *CreatePollParams) (*PollsResponse, error) {
-	resp, err := c.postAsJSON("/polls", &ManyPolls{}, params)
+func (c *Client) CreatePoll(params *CreatePollParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.postAsJSON("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +99,8 @@ type EndPollParams struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) EndPoll(params *EndPollParams) (*PollsResponse, error) {
-	resp, err := c.patchAsJSON("/polls", &ManyPolls{}, params)
+func (c *Client) EndPoll(params *EndPollParams, opts ...Options) (*PollsResponse, error) {
+	resp, err := c.patchAsJSON("/polls", &ManyPolls{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/polls.go
+++ b/polls.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Poll struct {
 	ID                         string       `json:"id"`
 	BroadcasterID              string       `json:"broadcaster_id"`
@@ -48,8 +50,8 @@ type GetPollsResponse struct {
 }
 
 // Required scope: channel:read:polls
-func (c *Client) GetPolls(params *PollsParams, opts ...Options) (*PollsResponse, error) {
-	resp, err := c.get("/polls", &ManyPolls{}, params, opts...)
+func (c *Client) GetPolls(ctx context.Context, params *PollsParams, opts ...Option) (*PollsResponse, error) {
+	resp, err := c.get(ctx, "/polls", &ManyPolls{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -78,8 +80,8 @@ type PollChoiceParam struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) CreatePoll(params *CreatePollParams, opts ...Options) (*PollsResponse, error) {
-	resp, err := c.postAsJSON("/polls", &ManyPolls{}, params, opts...)
+func (c *Client) CreatePoll(ctx context.Context, params *CreatePollParams, opts ...Option) (*PollsResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/polls", &ManyPolls{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +101,8 @@ type EndPollParams struct {
 }
 
 // Required scope: channel:manage:polls
-func (c *Client) EndPoll(params *EndPollParams, opts ...Options) (*PollsResponse, error) {
-	resp, err := c.patchAsJSON("/polls", &ManyPolls{}, params, opts...)
+func (c *Client) EndPoll(ctx context.Context, params *EndPollParams, opts ...Option) (*PollsResponse, error) {
+	resp, err := c.patchAsJSON(ctx, "/polls", &ManyPolls{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/predictions.go
+++ b/predictions.go
@@ -56,8 +56,8 @@ type GetPredictionsResponse struct {
 }
 
 // Required scope: channel:read:predictions
-func (c *Client) GetPredictions(params *PredictionsParams) (*PredictionsResponse, error) {
-	resp, err := c.get("/predictions", &ManyPredictions{}, params)
+func (c *Client) GetPredictions(params *PredictionsParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.get("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ type PredictionChoiceParam struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) CreatePrediction(params *CreatePredictionParams) (*PredictionsResponse, error) {
-	resp, err := c.postAsJSON("/predictions", &ManyPredictions{}, params)
+func (c *Client) CreatePrediction(params *CreatePredictionParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.postAsJSON("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +104,8 @@ type EndPredictionParams struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) EndPrediction(params *EndPredictionParams) (*PredictionsResponse, error) {
-	resp, err := c.patchAsJSON("/predictions", &ManyPredictions{}, params)
+func (c *Client) EndPrediction(params *EndPredictionParams, opts ...Options) (*PredictionsResponse, error) {
+	resp, err := c.patchAsJSON("/predictions", &ManyPredictions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/predictions.go
+++ b/predictions.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 // Prediction ... same struct as Poll
 type Prediction struct {
 	ID                   string     `json:"id"`
@@ -56,8 +58,8 @@ type GetPredictionsResponse struct {
 }
 
 // Required scope: channel:read:predictions
-func (c *Client) GetPredictions(params *PredictionsParams, opts ...Options) (*PredictionsResponse, error) {
-	resp, err := c.get("/predictions", &ManyPredictions{}, params, opts...)
+func (c *Client) GetPredictions(ctx context.Context, params *PredictionsParams, opts ...Option) (*PredictionsResponse, error) {
+	resp, err := c.get(ctx, "/predictions", &ManyPredictions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +84,8 @@ type PredictionChoiceParam struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) CreatePrediction(params *CreatePredictionParams, opts ...Options) (*PredictionsResponse, error) {
-	resp, err := c.postAsJSON("/predictions", &ManyPredictions{}, params, opts...)
+func (c *Client) CreatePrediction(ctx context.Context, params *CreatePredictionParams, opts ...Option) (*PredictionsResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/predictions", &ManyPredictions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +106,8 @@ type EndPredictionParams struct {
 }
 
 // Required scope: channel:manage:predictions
-func (c *Client) EndPrediction(params *EndPredictionParams, opts ...Options) (*PredictionsResponse, error) {
-	resp, err := c.patchAsJSON("/predictions", &ManyPredictions{}, params, opts...)
+func (c *Client) EndPrediction(ctx context.Context, params *EndPredictionParams, opts ...Option) (*PredictionsResponse, error) {
+	resp, err := c.patchAsJSON(ctx, "/predictions", &ManyPredictions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/stream_markers.go
+++ b/stream_markers.go
@@ -49,8 +49,8 @@ type StreamMarkersParams struct {
 // of an user being recorded as VOD.
 //
 // Required Scope: user:read:broadcast
-func (c *Client) GetStreamMarkers(params *StreamMarkersParams) (*StreamMarkersResponse, error) {
-	resp, err := c.get("/streams/markers", &ManyStreamMarkers{}, params)
+func (c *Client) GetStreamMarkers(params *StreamMarkersParams, opts ...Options) (*StreamMarkersResponse, error) {
+	resp, err := c.get("/streams/markers", &ManyStreamMarkers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ type CreateStreamMarkerParams struct {
 // https://dev.twitch.tv/docs/api/reference/#create-stream-marker
 //
 // Required Scope: user:edit:broadcast
-func (c *Client) CreateStreamMarker(params *CreateStreamMarkerParams) (*CreateStreamMarkerResponse, error) {
-	resp, err := c.post("/streams/markers", &ManyCreateStreamMarkers{}, params)
+func (c *Client) CreateStreamMarker(params *CreateStreamMarkerParams, opts ...Options) (*CreateStreamMarkerResponse, error) {
+	resp, err := c.post("/streams/markers", &ManyCreateStreamMarkers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/stream_markers.go
+++ b/stream_markers.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Marker struct {
 	ID              string `json:"id"`
 	CreatedAt       Time   `json:"created_at"`
@@ -49,8 +51,8 @@ type StreamMarkersParams struct {
 // of an user being recorded as VOD.
 //
 // Required Scope: user:read:broadcast
-func (c *Client) GetStreamMarkers(params *StreamMarkersParams, opts ...Options) (*StreamMarkersResponse, error) {
-	resp, err := c.get("/streams/markers", &ManyStreamMarkers{}, params, opts...)
+func (c *Client) GetStreamMarkers(ctx context.Context, params *StreamMarkersParams, opts ...Option) (*StreamMarkersResponse, error) {
+	resp, err := c.get(ctx, "/streams/markers", &ManyStreamMarkers{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +94,8 @@ type CreateStreamMarkerParams struct {
 // https://dev.twitch.tv/docs/api/reference/#create-stream-marker
 //
 // Required Scope: user:edit:broadcast
-func (c *Client) CreateStreamMarker(params *CreateStreamMarkerParams, opts ...Options) (*CreateStreamMarkerResponse, error) {
-	resp, err := c.post("/streams/markers", &ManyCreateStreamMarkers{}, params, opts...)
+func (c *Client) CreateStreamMarker(ctx context.Context, params *CreateStreamMarkerParams, opts ...Option) (*CreateStreamMarkerResponse, error) {
+	resp, err := c.post(ctx, "/streams/markers", &ManyCreateStreamMarkers{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/streams.go
+++ b/streams.go
@@ -1,6 +1,9 @@
 package helix
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type Stream struct {
 	ID           string    `json:"id"`
@@ -42,8 +45,8 @@ type StreamsParams struct {
 
 // GetStreams returns a list of live channels based on the search parameters.
 // To query offline channels, use SearchChannels.
-func (c *Client) GetStreams(params *StreamsParams, opts ...Options) (*StreamsResponse, error) {
-	resp, err := c.get("/streams", &ManyStreams{}, params, opts...)
+func (c *Client) GetStreams(ctx context.Context, params *StreamsParams, opts ...Option) (*StreamsResponse, error) {
+	resp, err := c.get(ctx, "/streams", &ManyStreams{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +72,8 @@ type FollowedStreamsParams struct {
 // may be duplicate or missing streams, as viewers join and leave streams.
 //
 // Required scope: user:read:follows
-func (c *Client) GetFollowedStream(params *FollowedStreamsParams, opts ...Options) (*StreamsResponse, error) {
-	resp, err := c.get("/streams/followed", &ManyStreams{}, params, opts...)
+func (c *Client) GetFollowedStream(ctx context.Context, params *FollowedStreamsParams, opts ...Option) (*StreamsResponse, error) {
+	resp, err := c.get(ctx, "/streams/followed", &ManyStreams{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/streams.go
+++ b/streams.go
@@ -42,8 +42,8 @@ type StreamsParams struct {
 
 // GetStreams returns a list of live channels based on the search parameters.
 // To query offline channels, use SearchChannels.
-func (c *Client) GetStreams(params *StreamsParams) (*StreamsResponse, error) {
-	resp, err := c.get("/streams", &ManyStreams{}, params)
+func (c *Client) GetStreams(params *StreamsParams, opts ...Options) (*StreamsResponse, error) {
+	resp, err := c.get("/streams", &ManyStreams{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +69,8 @@ type FollowedStreamsParams struct {
 // may be duplicate or missing streams, as viewers join and leave streams.
 //
 // Required scope: user:read:follows
-func (c *Client) GetFollowedStream(params *FollowedStreamsParams) (*StreamsResponse, error) {
-	resp, err := c.get("/streams/followed", &ManyStreams{}, params)
+func (c *Client) GetFollowedStream(params *FollowedStreamsParams, opts ...Options) (*StreamsResponse, error) {
+	resp, err := c.get("/streams/followed", &ManyStreams{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -63,8 +63,8 @@ type UserSubscriptionsParams struct {
 // Broadcasters can only request their own subscriptions.
 //
 // Required scope: channel:read:subscriptions
-func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsResponse, error) {
-	resp, err := c.get("/subscriptions", &ManySubscriptions{}, params)
+func (c *Client) GetSubscriptions(params *SubscriptionsParams, opts ...Options) (*SubscriptionsResponse, error) {
+	resp, err := c.get("/subscriptions", &ManySubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (c *Client) GetSubscriptions(params *SubscriptionsParams) (*SubscriptionsRe
 // CheckUserSubscription Check if a specific user is subscribed to a specific channel
 //
 // Required scope: user:read:subscriptions
-func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams) (*UserSubscriptionResponse, error) {
-	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params)
+func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams, opts ...Options) (*UserSubscriptionResponse, error) {
+	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Subscription struct {
 	BroadcasterID    string `json:"broadcaster_id"`
 	BroadcasterLogin string `json:"broadcaster_login"`
@@ -63,8 +65,8 @@ type UserSubscriptionsParams struct {
 // Broadcasters can only request their own subscriptions.
 //
 // Required scope: channel:read:subscriptions
-func (c *Client) GetSubscriptions(params *SubscriptionsParams, opts ...Options) (*SubscriptionsResponse, error) {
-	resp, err := c.get("/subscriptions", &ManySubscriptions{}, params, opts...)
+func (c *Client) GetSubscriptions(ctx context.Context, params *SubscriptionsParams, opts ...Option) (*SubscriptionsResponse, error) {
+	resp, err := c.get(ctx, "/subscriptions", &ManySubscriptions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +84,8 @@ func (c *Client) GetSubscriptions(params *SubscriptionsParams, opts ...Options) 
 // CheckUserSubscription Check if a specific user is subscribed to a specific channel
 //
 // Required scope: user:read:subscriptions
-func (c *Client) CheckUserSubscription(params *UserSubscriptionsParams, opts ...Options) (*UserSubscriptionResponse, error) {
-	resp, err := c.get("/subscriptions/user", &ManyUserSubscriptions{}, params, opts...)
+func (c *Client) CheckUserSubscription(ctx context.Context, params *UserSubscriptionsParams, opts ...Option) (*UserSubscriptionResponse, error) {
+	resp, err := c.get(ctx, "/subscriptions/user", &ManyUserSubscriptions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/user_extensions.go
+++ b/user_extensions.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type UserExtension struct {
 	CanActivate bool     `json:"can_activate"`
 	ID          string   `json:"id"`
@@ -21,8 +23,8 @@ type UserExtensionsResponse struct {
 // identified by a Bearer token
 //
 // Required scope: user:read:broadcast
-func (c *Client) GetUserExtensions(opts ...Options) (*UserExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions/list", &ManyUserExtensions{}, nil, opts...)
+func (c *Client) GetUserExtensions(ctx context.Context, opts ...Option) (*UserExtensionsResponse, error) {
+	resp, err := c.get(ctx, "/users/extensions/list", &ManyUserExtensions{}, nil, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +68,8 @@ type UserActiveExtensionsParams struct {
 // by a user ID or Bearer token.
 //
 // Optional scope: user:read:broadcast or user:edit:broadcast
-func (c *Client) GetUserActiveExtensions(params *UserActiveExtensionsParams, opts ...Options) (*UserActiveExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions", &UserActiveExtensionSet{}, params, opts...)
+func (c *Client) GetUserActiveExtensions(ctx context.Context, params *UserActiveExtensionsParams, opts ...Option) (*UserActiveExtensionsResponse, error) {
+	resp, err := c.get(ctx, "/users/extensions", &UserActiveExtensionSet{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +95,9 @@ type wrappedUpdateUserExtensionsPayload struct {
 // If you try to activate a given extension under multiple extension types, the last write wins (and there is no guarantee of write order).
 //
 // Required scope: user:edit:broadcast
-func (c *Client) UpdateUserExtensions(payload *UpdateUserExtensionsPayload, opts ...Options) (*UserActiveExtensionsResponse, error) {
+func (c *Client) UpdateUserExtensions(ctx context.Context, payload *UpdateUserExtensionsPayload, opts ...Option) (*UserActiveExtensionsResponse, error) {
 	normalizedPayload := &wrappedUpdateUserExtensionsPayload{UpdateUserExtensionsPayload: *payload}
-	resp, err := c.putAsJSON("/users/extensions", &UserActiveExtensionSet{}, normalizedPayload, opts...)
+	resp, err := c.putAsJSON(ctx, "/users/extensions", &UserActiveExtensionSet{}, normalizedPayload, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/user_extensions.go
+++ b/user_extensions.go
@@ -21,8 +21,8 @@ type UserExtensionsResponse struct {
 // identified by a Bearer token
 //
 // Required scope: user:read:broadcast
-func (c *Client) GetUserExtensions() (*UserExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions/list", &ManyUserExtensions{}, nil)
+func (c *Client) GetUserExtensions(opts ...Options) (*UserExtensionsResponse, error) {
+	resp, err := c.get("/users/extensions/list", &ManyUserExtensions{}, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ type UserActiveExtensionsParams struct {
 // by a user ID or Bearer token.
 //
 // Optional scope: user:read:broadcast or user:edit:broadcast
-func (c *Client) GetUserActiveExtensions(params *UserActiveExtensionsParams) (*UserActiveExtensionsResponse, error) {
-	resp, err := c.get("/users/extensions", &UserActiveExtensionSet{}, params)
+func (c *Client) GetUserActiveExtensions(params *UserActiveExtensionsParams, opts ...Options) (*UserActiveExtensionsResponse, error) {
+	resp, err := c.get("/users/extensions", &UserActiveExtensionSet{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +93,9 @@ type wrappedUpdateUserExtensionsPayload struct {
 // If you try to activate a given extension under multiple extension types, the last write wins (and there is no guarantee of write order).
 //
 // Required scope: user:edit:broadcast
-func (c *Client) UpdateUserExtensions(payload *UpdateUserExtensionsPayload) (*UserActiveExtensionsResponse, error) {
+func (c *Client) UpdateUserExtensions(payload *UpdateUserExtensionsPayload, opts ...Options) (*UserActiveExtensionsResponse, error) {
 	normalizedPayload := &wrappedUpdateUserExtensionsPayload{UpdateUserExtensionsPayload: *payload}
-	resp, err := c.putAsJSON("/users/extensions", &UserActiveExtensionSet{}, normalizedPayload)
+	resp, err := c.putAsJSON("/users/extensions", &UserActiveExtensionSet{}, normalizedPayload, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -1,6 +1,9 @@
 package helix
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type User struct {
 	ID              string `json:"id"`
@@ -35,8 +38,8 @@ type UsersParams struct {
 // a user ID nor a login name is specified, the user is looked up by Bearer token.
 //
 // Optional scope: user:read:email
-func (c *Client) GetUsers(params *UsersParams, opts ...Options) (*UsersResponse, error) {
-	resp, err := c.get("/users", &ManyUsers{}, params, opts...)
+func (c *Client) GetUsers(ctx context.Context, params *UsersParams, opts ...Option) (*UsersResponse, error) {
+	resp, err := c.get(ctx, "/users", &ManyUsers{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +59,8 @@ type UpdateUserParams struct {
 // by a Bearer token.
 //
 // Required scope: user:edit
-func (c *Client) UpdateUser(params *UpdateUserParams, opts ...Options) (*UsersResponse, error) {
-	resp, err := c.put("/users", &ManyUsers{}, params, opts...)
+func (c *Client) UpdateUser(ctx context.Context, params *UpdateUserParams, opts ...Option) (*UsersResponse, error) {
+	resp, err := c.put(ctx, "/users", &ManyUsers{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +103,8 @@ type UsersFollowsParams struct {
 // Information returned is sorted in order, most recent follow first. This can return
 // information like “who is lirik following,” “who is following lirik,” or “is user X
 // following user Y.”
-func (c *Client) GetUsersFollows(params *UsersFollowsParams, opts ...Options) (*UsersFollowsResponse, error) {
-	resp, err := c.get("/users/follows", &ManyFollows{}, params, opts...)
+func (c *Client) GetUsersFollows(ctx context.Context, params *UsersFollowsParams, opts ...Option) (*UsersFollowsResponse, error) {
+	resp, err := c.get(ctx, "/users/follows", &ManyFollows{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +143,8 @@ type UsersBlockedParams struct {
 // GetUsersBlocked : Gets a specified user’s block list.
 //
 // Required scope: user:read:blocked_users
-func (c *Client) GetUsersBlocked(params *UsersBlockedParams, opts ...Options) (*UsersBlockedResponse, error) {
-	resp, err := c.get("/users/blocks", &ManyUsersBlocked{}, params, opts...)
+func (c *Client) GetUsersBlocked(ctx context.Context, params *UsersBlockedParams, opts ...Option) (*UsersBlockedResponse, error) {
+	resp, err := c.get(ctx, "/users/blocks", &ManyUsersBlocked{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +170,8 @@ type BlockUserParams struct {
 // BlockUser : Blocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) BlockUser(params *BlockUserParams, opts ...Options) (*BlockUserResponse, error) {
-	resp, err := c.put("/users/blocks", nil, params, opts...)
+func (c *Client) BlockUser(ctx context.Context, params *BlockUserParams, opts ...Option) (*BlockUserResponse, error) {
+	resp, err := c.put(ctx, "/users/blocks", nil, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +189,8 @@ type UnblockUserParams struct {
 // UnblockUser : Unblocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) UnblockUser(params *UnblockUserParams, opts ...Options) (*BlockUserResponse, error) {
-	resp, err := c.delete("/users/blocks", nil, params, opts...)
+func (c *Client) UnblockUser(ctx context.Context, params *UnblockUserParams, opts ...Option) (*BlockUserResponse, error) {
+	resp, err := c.delete(ctx, "/users/blocks", nil, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -35,8 +35,8 @@ type UsersParams struct {
 // a user ID nor a login name is specified, the user is looked up by Bearer token.
 //
 // Optional scope: user:read:email
-func (c *Client) GetUsers(params *UsersParams) (*UsersResponse, error) {
-	resp, err := c.get("/users", &ManyUsers{}, params)
+func (c *Client) GetUsers(params *UsersParams, opts ...Options) (*UsersResponse, error) {
+	resp, err := c.get("/users", &ManyUsers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ type UpdateUserParams struct {
 // by a Bearer token.
 //
 // Required scope: user:edit
-func (c *Client) UpdateUser(params *UpdateUserParams) (*UsersResponse, error) {
-	resp, err := c.put("/users", &ManyUsers{}, params)
+func (c *Client) UpdateUser(params *UpdateUserParams, opts ...Options) (*UsersResponse, error) {
+	resp, err := c.put("/users", &ManyUsers{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ type UsersFollowsParams struct {
 // Information returned is sorted in order, most recent follow first. This can return
 // information like “who is lirik following,” “who is following lirik,” or “is user X
 // following user Y.”
-func (c *Client) GetUsersFollows(params *UsersFollowsParams) (*UsersFollowsResponse, error) {
-	resp, err := c.get("/users/follows", &ManyFollows{}, params)
+func (c *Client) GetUsersFollows(params *UsersFollowsParams, opts ...Options) (*UsersFollowsResponse, error) {
+	resp, err := c.get("/users/follows", &ManyFollows{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +140,8 @@ type UsersBlockedParams struct {
 // GetUsersBlocked : Gets a specified user’s block list.
 //
 // Required scope: user:read:blocked_users
-func (c *Client) GetUsersBlocked(params *UsersBlockedParams) (*UsersBlockedResponse, error) {
-	resp, err := c.get("/users/blocks", &ManyUsersBlocked{}, params)
+func (c *Client) GetUsersBlocked(params *UsersBlockedParams, opts ...Options) (*UsersBlockedResponse, error) {
+	resp, err := c.get("/users/blocks", &ManyUsersBlocked{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ type BlockUserParams struct {
 // BlockUser : Blocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) BlockUser(params *BlockUserParams) (*BlockUserResponse, error) {
-	resp, err := c.put("/users/blocks", nil, params)
+func (c *Client) BlockUser(params *BlockUserParams, opts ...Options) (*BlockUserResponse, error) {
+	resp, err := c.put("/users/blocks", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +186,8 @@ type UnblockUserParams struct {
 // UnblockUser : Unblocks the specified user on behalf of the authenticated user.
 //
 // Required scope: user:manage:blocked_users
-func (c *Client) UnblockUser(params *UnblockUserParams) (*BlockUserResponse, error) {
-	resp, err := c.delete("/users/blocks", nil, params)
+func (c *Client) UnblockUser(params *UnblockUserParams, opts ...Options) (*BlockUserResponse, error) {
+	resp, err := c.delete("/users/blocks", nil, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/videos.go
+++ b/videos.go
@@ -60,8 +60,8 @@ type DeleteVideosResponse struct {
 
 // GetVideos gets video information by video ID (one or more), user ID (one only),
 // or game ID (one only).
-func (c *Client) GetVideos(params *VideosParams) (*VideosResponse, error) {
-	resp, err := c.get("/videos", &ManyVideos{}, params)
+func (c *Client) GetVideos(params *VideosParams, opts ...Options) (*VideosResponse, error) {
+	resp, err := c.get("/videos", &ManyVideos{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +76,8 @@ func (c *Client) GetVideos(params *VideosParams) (*VideosResponse, error) {
 
 // DeleteVideos delete one or more videos (max 5)
 // Required scope: channel:manage:videos
-func (c *Client) DeleteVideos(params *DeleteVideosParams) (*DeleteVideosResponse, error) {
-	resp, err := c.delete("/videos", &DeleteVideosResponse{}, params)
+func (c *Client) DeleteVideos(params *DeleteVideosParams, opts ...Options) (*DeleteVideosResponse, error) {
+	resp, err := c.delete("/videos", &DeleteVideosResponse{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/videos.go
+++ b/videos.go
@@ -1,5 +1,7 @@
 package helix
 
+import "context"
+
 type Video struct {
 	ID            string              `json:"id"`
 	UserID        string              `json:"user_id"`
@@ -60,8 +62,8 @@ type DeleteVideosResponse struct {
 
 // GetVideos gets video information by video ID (one or more), user ID (one only),
 // or game ID (one only).
-func (c *Client) GetVideos(params *VideosParams, opts ...Options) (*VideosResponse, error) {
-	resp, err := c.get("/videos", &ManyVideos{}, params, opts...)
+func (c *Client) GetVideos(ctx context.Context, params *VideosParams, opts ...Option) (*VideosResponse, error) {
+	resp, err := c.get(ctx, "/videos", &ManyVideos{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +78,8 @@ func (c *Client) GetVideos(params *VideosParams, opts ...Options) (*VideosRespon
 
 // DeleteVideos delete one or more videos (max 5)
 // Required scope: channel:manage:videos
-func (c *Client) DeleteVideos(params *DeleteVideosParams, opts ...Options) (*DeleteVideosResponse, error) {
-	resp, err := c.delete("/videos", &DeleteVideosResponse{}, params, opts...)
+func (c *Client) DeleteVideos(ctx context.Context, params *DeleteVideosParams, opts ...Option) (*DeleteVideosResponse, error) {
+	resp, err := c.delete(ctx, "/videos", &DeleteVideosResponse{}, params, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -1,6 +1,7 @@
 package helix
 
 import (
+	"context"
 	"net/http"
 	"regexp"
 )
@@ -29,8 +30,8 @@ type WebhookSubscriptionsParams struct {
 
 // GetWebhookSubscriptions gets webhook subscriptions, in order of expiration.
 // Requires an app access token.
-func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams, opts ...Options) (*WebhookSubscriptionsResponse, error) {
-	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params, opts...)
+func (c *Client) GetWebhookSubscriptions(ctx context.Context, params *WebhookSubscriptionsParams, opts ...Option) (*WebhookSubscriptionsResponse, error) {
+	resp, err := c.get(ctx, "/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +57,8 @@ type WebhookSubscriptionPayload struct {
 	Secret       string `json:"hub.secret,omitempty"`
 }
 
-func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload, opts ...Options) (*WebhookSubscriptionResponse, error) {
-	resp, err := c.postAsJSON("/webhooks/hub", nil, payload, opts...)
+func (c *Client) PostWebhookSubscription(ctx context.Context, payload *WebhookSubscriptionPayload, opts ...Option) (*WebhookSubscriptionResponse, error) {
+	resp, err := c.postAsJSON(ctx, "/webhooks/hub", nil, payload, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -29,8 +29,8 @@ type WebhookSubscriptionsParams struct {
 
 // GetWebhookSubscriptions gets webhook subscriptions, in order of expiration.
 // Requires an app access token.
-func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams) (*WebhookSubscriptionsResponse, error) {
-	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params)
+func (c *Client) GetWebhookSubscriptions(params *WebhookSubscriptionsParams, opts ...Options) (*WebhookSubscriptionsResponse, error) {
+	resp, err := c.get("/webhooks/subscriptions", &ManyWebhookSubscriptions{}, params, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ type WebhookSubscriptionPayload struct {
 	Secret       string `json:"hub.secret,omitempty"`
 }
 
-func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload) (*WebhookSubscriptionResponse, error) {
-	resp, err := c.postAsJSON("/webhooks/hub", nil, payload)
+func (c *Client) PostWebhookSubscription(payload *WebhookSubscriptionPayload, opts ...Options) (*WebhookSubscriptionResponse, error) {
+	resp, err := c.postAsJSON("/webhooks/hub", nil, payload, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Rebased main from nicklaw5 to get more functions that needed updating.
- The Go context has been added to functions on `helix.Client` where needed.
- Instead of passing a slice of `Options` we now have an `Option` which is used to build the client and can be provided on individual calls.
- Add example with documentation that will allow user to go to link and see their user id back in the terminal.